### PR TITLE
Temporarily disable dependabot python pacakge updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,11 @@
 version: 2
 
 updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 20
+  #- package-ecosystem: "pip"
+  #  directory: "/"
+  #  schedule:
+  #    interval: "weekly"
+  #  open-pull-requests-limit: 20
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
It runs on linux so it breaks windows packaging. We need to fix the
windows/python packaging issue before turning it on again
