### PR TITLE
Tweaks for working on Windows

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.11
+  python: python3.10
 
 repos:
   - repo: local

--- a/justfile
+++ b/justfile
@@ -33,7 +33,7 @@ clean:
 
 
 # ensure valid virtualenv
-virtualenv:
+virtualenv: _env
     #!/usr/bin/env bash
     # allow users to specify python version in .env
     PYTHON_VERSION=${PYTHON_VERSION:-$DEFAULT_PYTHON}
@@ -43,6 +43,11 @@ virtualenv:
 
     # ensure we have pip-tools so we can run pip-compile
     test -e $BIN/pip-compile || $PIP install pip-tools
+
+
+_env:
+    #!/usr/bin/env bash
+    test -f .env || cp .dotenv-sample .env
 
 
 _compile src dst *args: virtualenv

--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -3,6 +3,7 @@ django-browser-reload
 django-extensions
 django-htmx
 django-vite
+environs
 pyoxidizer
 requests
 slippers

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -14,6 +14,8 @@ charset-normalizer==3.1.0
     # via requests
 click==8.1.3
     # via uvicorn
+colorama==0.4.6
+    # via click
 django==4.1.9
     # via
     #   -r requirements.prod.in
@@ -30,12 +32,20 @@ django-htmx==1.14.0
     # via -r requirements.prod.in
 django-vite==2.1.2
     # via -r requirements.prod.in
+environs==9.5.0
+    # via -r requirements.prod.in
 h11==0.14.0
     # via uvicorn
 idna==3.4
     # via requests
+marshmallow==3.19.0
+    # via environs
+packaging==23.1
+    # via marshmallow
 pyoxidizer==0.24.0
     # via -r requirements.prod.in
+python-dotenv==1.0.0
+    # via environs
 pyyaml==6.0
     # via slippers
 requests==2.31.0
@@ -46,6 +56,8 @@ sqlparse==0.4.4
     # via django
 typing-extensions==4.6.3
     # via asgiref
+tzdata==2023.3
+    # via django
 urllib3==2.0.3
     # via requests
 uvicorn==0.22.0


### PR DESCRIPTION
* SACRO uses python 3.10, so pre-coomit hooks should use python 3.10 as well
* Adding missing dependency
* Ensure dotenv file is created from the sample, if it doesn't already exist, for local dev