### PR TITLE
Make assets load in the pyoxidizer build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
           install-just: true
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
           cache: "npm"
           cache-dependency-path: "**/package-lock.json"
       - name: Run tests
@@ -48,7 +48,7 @@ jobs:
           python-version: "3.11"
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
           cache: "npm"
           cache-dependency-path: "**/package-lock.json"
       # our just setup doesn't make just available on the path

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,6 @@ __pycache__
 sacro-app/dist
 node_modules/
 assets/dist
-staticfiles/
+sacro/staticfiles/
 .env
 *.sqlite3

--- a/justfile
+++ b/justfile
@@ -133,7 +133,7 @@ run: devenv
     $BIN/python manage.py migrate
     $BIN/python manage.py runserver
 
-build:
+build: collectstatic
     $BIN/pyoxidizer build --release
 
 eslint:
@@ -157,7 +157,7 @@ assets-clean:
     rm -rf staticfiles
 
 # Build the Node.js assets
-assets-build:
+assets-build: assets-install
     #!/usr/bin/env bash
     set -eu
 
@@ -174,10 +174,10 @@ assets-build:
     touch assets/dist/.written
 
 
-assets: assets-install assets-build
+assets: assets-build
 
 assets-rebuild: assets-clean assets
 
 # Ensure django's collectstatic is run if needed
-collectstatic: devenv
+collectstatic: devenv assets
     ./scripts/collect-me-maybe.sh $BIN/python

--- a/pyoxidizer.bzl
+++ b/pyoxidizer.bzl
@@ -20,7 +20,7 @@ def make_exe():
 
     # Enable support for non-classified "file" resources to be added to
     # resource collections.
-    # policy.allow_files = True
+    policy.allow_files = True
 
     # Control support for loading Python extensions and other shared libraries
     # from memory. This is only supported on Windows and is ignored on other
@@ -90,6 +90,7 @@ def make_exe():
     # policy.resources_location = "in-memory"
 
     # Use filesystem-relative location for adding resources by default.
+    # we need to use filesytem resources because django makes liberal use of __file__
     policy.resources_location = "filesystem-relative:lib"
 
     # Attempt to add resources relative to the built binary when
@@ -173,11 +174,11 @@ def make_exe():
 
     # Control whether `oxidized_importer` is the first importer on
     # `sys.meta_path`.
-    # python_config.oxidized_importer = False
+    python_config.oxidized_importer = False
 
     # Enable the standard path-based importer which attempts to load
     # modules from the filesystem.
-    # python_config.filesystem_importer = True
+    python_config.filesystem_importer = True
 
     # Set `sys.frozen = False`
     # python_config.sys_frozen = False
@@ -255,7 +256,7 @@ def make_exe():
     # Python packages.
     exe.add_python_resources(exe.read_package_root(
         path=".",
-        packages=["sacro"],
+        packages=["sacro",],
     ))
 
     # Discover Python files from a virtualenv and add them to our embedded

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -6,7 +6,9 @@
 
 black
 coverage
+django-browser-reload
 pip-tools
 pre-commit
 pytest
 ruff
+pyoxidizer

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -4,6 +4,10 @@
 #
 #    pip-compile --allow-unsafe --output-file=requirements.dev.txt requirements.dev.in
 #
+asgiref==3.7.2
+    # via
+    #   -c requirements.prod.txt
+    #   django
 black==23.3.0
     # via -r requirements.dev.in
 build==0.10.0
@@ -25,6 +29,12 @@ coverage==7.2.7
     # via -r requirements.dev.in
 distlib==0.3.6
     # via virtualenv
+django==4.1.9
+    # via
+    #   -c requirements.prod.txt
+    #   django-browser-reload
+django-browser-reload==1.9.0
+    # via -r requirements.dev.in
 exceptiongroup==1.1.1
     # via pytest
 filelock==3.12.0
@@ -55,6 +65,8 @@ pluggy==1.0.0
     # via pytest
 pre-commit==3.3.2
     # via -r requirements.dev.in
+pyoxidizer==0.24.0
+    # via -r requirements.dev.in
 pyproject-hooks==1.0.0
     # via build
 pytest==7.3.1
@@ -65,11 +77,24 @@ pyyaml==6.0
     #   pre-commit
 ruff==0.0.272
     # via -r requirements.dev.in
+sqlparse==0.4.4
+    # via
+    #   -c requirements.prod.txt
+    #   django
 tomli==2.0.1
     # via
     #   black
     #   build
+    #   pyproject-hooks
     #   pytest
+typing-extensions==4.6.3
+    # via
+    #   -c requirements.prod.txt
+    #   asgiref
+tzdata==2023.3
+    # via
+    #   -c requirements.prod.txt
+    #   django
 virtualenv==20.23.0
     # via pre-commit
 wheel==0.40.0

--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -1,10 +1,8 @@
 django<4.2
-django-browser-reload
 django-extensions
 django-htmx
 django-vite
 environs
-pyoxidizer
 requests
 slippers
 uvicorn

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -19,13 +19,10 @@ colorama==0.4.6
 django==4.1.9
     # via
     #   -r requirements.prod.in
-    #   django-browser-reload
     #   django-extensions
     #   django-htmx
     #   django-vite
     #   slippers
-django-browser-reload==1.9.0
-    # via -r requirements.prod.in
 django-extensions==3.2.3
     # via -r requirements.prod.in
 django-htmx==1.14.0
@@ -42,8 +39,6 @@ marshmallow==3.19.0
     # via environs
 packaging==23.1
     # via marshmallow
-pyoxidizer==0.24.0
-    # via -r requirements.prod.in
 python-dotenv==1.0.0
     # via environs
 pyyaml==6.0

--- a/sacro/settings.py
+++ b/sacro/settings.py
@@ -38,7 +38,6 @@ ALLOWED_HOSTS = ["*"]
 
 INSTALLED_APPS = [
     "sacro",
-    "django_browser_reload",
     "django_extensions",
     "django_vite",
     "slippers",
@@ -59,8 +58,16 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "django_browser_reload.middleware.BrowserReloadMiddleware",
 ]
+
+# add dev tools only when needed
+if DEBUG:
+    import importlib.util
+
+    if importlib.util.find_spec("django_browser_reload"):
+        INSTALLED_APPS.insert(0, "django_browser_reload")
+        MIDDLEWARE.append("django_browser_reload.middleware.BrowserReloadMiddleware")
+
 
 ROOT_URLCONF = "sacro.urls"
 
@@ -146,7 +153,8 @@ STATICFILES_DIRS = [
     BASE_DIR / "static",
     env.path("BUILT_ASSETS", default=BASE_DIR / "assets" / "dist"),
 ]
-STATIC_ROOT = env.path("STATIC_ROOT", default=BASE_DIR / "staticfiles")
+# we put staticfiles inside the python module, so that its easy to bundle with pyoxidizer
+STATIC_ROOT = env.path("STATIC_ROOT", default=BASE_DIR / "sacro/staticfiles")
 STATIC_URL = "/static/"
 
 DJANGO_VITE_ASSETS_PATH = BASE_DIR / "assets" / "dist"


### PR DESCRIPTION
This required enabling regular file importing in pyoxidizer config so
that django can load its templatetags and such, as well as including the
built static assets in the app.

Includes a slew of small other fixies in the process
 -  pyoxidizer and django_browser reload are dev dependency
 -  node version in CI to 20
