### PR TITLE
Upload msi and test data as action artifact

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Build app
         run: just sacro-app/build
 
-  test-windows:
+  build-windows:
     permissions:
       contents: write
     runs-on: windows-2022

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,8 @@ jobs:
         run: just sacro-app/build
 
   test-windows:
+    permissions:
+      contents: write
     runs-on: windows-2022
 
     steps:
@@ -59,6 +61,14 @@ jobs:
         run: just build
       - name: Build app
         run: just sacro-app/build
+      - name: Upload build
+        if: success() && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v3
+        with:
+          name: SACRO latest build with test data
+          path: |
+            sacro-app/dist/SACRO*.msi
+            outputs/*
 
   lint-dockerfile:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This uploads the build MSI and test outputs as an action artifacts.

Artifacts are retained for 90 days by default.  Finding the latest artifact built off main can be non-obvious, hopfully https://nightly.link might be able to help us here.

But first we need to have built artifacts on `main`, so we need to land this.