### PR TITLE
POST explicit list of files to review endpoint

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1,5 +1,18 @@
 # Notes for developers
 
+## Overview
+
+The SACRO app consists of two parts:
+
+1) a python webapp that renders a set of ACRO outputs for review
+2) an electron app and installer that bundles the python web app
+
+
+The python web app is designed to be able to be used as normally deployed web
+site. The electron app packages a pre-built version of this webapp with a chrome
+based browser.
+
+
 ## System requirements
 
 ### Windows
@@ -32,13 +45,12 @@ just assets
 Run the tests with:
 ```
 just test <args>
-just run  # run python server
 ```
 
 ## Test data
 
 The script `data/test-nursery.py` uses ACRO to generate outputs from a public test
-dataset. It will generate some test outputs in `outputs/`.
+dataset. These are automatically regenerated if needed by the `justfile` e.g. for `just test` or `just run`.  The outputs are generated in the `outputs/` directory.
 
 It can be run with the following command:
 
@@ -47,17 +59,17 @@ just test-outputs
 ```
 
 However, this won't always pick up new changes. For example, if new files are
-added to the test data. In this case it may be  necessary to force removal
+added to the test data. In this case it may be necessary to force removal
 of all the test data and regenerate it, by doing the following.
 ```
 just clean
 just test-outputs
 ```
 
-## Running the electon app
+## Running the electon app in dev mode
 
-You can run the development version the python webapp and then run the electron
-app pointing at that by setting the SACRO_URL env var.
+First, run the development version of the python webapp and then run the
+electron app pointing at that by setting the SACRO_URL env var.
 
 ```
 just run &
@@ -76,16 +88,32 @@ and then building the Windows installer (MSI).
 just build
 ```
 
-This builds the pyoxidizer binary of the python application for the current platform.
+This builds the pyoxidizer binary of the python application for the current
+platform. It can take a while.  The build executable and supporting files can be
+found in `build/$ARCH/release/install/sacro`.
+
 
 ### Building the electron GUI app
 
-The root directory contains our python web service, and is basically the same
-as all our other web services, but with pyoxidizer.bzl build config, and a
-`just build` command.
+The root directory contains our python web service, and is similar to all our
+other web services, but with the addition of the pyoxidizer.bzl build config,
+and a `just build` command.
 
-The sacro-app dir contains the electron and packaging config and tooling
+The `sacro-app` dir contains the electron and packaging config and tooling.
 
 ```
 just sacro-app/build
 ```
+
+This builds the installer, which can be found in `sacro-app/dist`
+
+### Testing the built application
+
+You can double click on the MSI, found in `sacro-app/dist`, to install it, which should also run it, opening
+a file dialog. You may need to click various Windows dialogs to approve the
+install.
+
+Navigate to the `outputs` directory and choose `test_results.json`. You should
+now be able to see the outputs rendered in the app.
+
+You can click on the `Approve and Download` button to download the files.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,51 @@
 # SACRO Outputs Viewer
 
-A viewer outputs produced using the ACRO tool
+A viewer for research outputs produced using the
+[ACRO](https://github.com/AI-SDC/ACRO) tools.
 
+It can load the JSON metadata output by the tool, and displays the outputs for
+an output checker to review. The reviewer can see each file, researcher
+comments, and as the outcomes of any statistical analysis performed by ACRO
+tools.
+
+It allow the output checker to approve or reject the outputs, and can generate a
+zip file with approved outputs for releasing.
+
+Warning: this tool is under active development, and not all features are
+complete at this point.
+
+## Installation
+
+The latest development version can be found here:
+
+https://opensafely.org/sacro/latest-windows-build
+
+Unzip this, and install the application by double clicking on the SACRO.msi file.
+
+This will install and then run the application.  Because the application is not
+yet signed, you will likely need to approve the installation, for which you may
+need admin priviledges. Depending on your local machines configuration, you may
+not be able to install it if you don't ahve admin access.
+
+When the installation completes, it will run the application.
+
+## Usage
+
+To view some ACRO outputs, you need to open the ACRO generated JSON file for
+those outputs.
+
+If you don't have any, you can use the test outputs we have included in the
+downloaded zip to get started with.
+
+Navigate to and select the `.json` file in the ACRO `outputs` directory (`results.json` by
+default). If  you are using the test outputs, it is `outputs\test_results.json`.
+
+In the appliction, you should now see the list of outputs on the left, and can
+select each one to view it.
+
+If you want to approve these outputs, you can click on the green "Approve and
+Download" button, which allow you to save a zip file with them all included. You
+can then continue with your normal release process.
 
 ## Developer docs
 

--- a/assets/src/scripts/_form-setup.js
+++ b/assets/src/scripts/_form-setup.js
@@ -1,9 +1,16 @@
-import { reviewUrl } from "./_data";
+import { reviewUrl, outputs } from "./_data";
 
 const formSetup = () => {
   const form = document.querySelector("#approveForm");
   const button = form.querySelector(`button[type="submit"]`);
   form.action = reviewUrl;
+
+  form.addEventListener("formdata", (ev) => {
+    // TODO: get from signal
+    for (const [output] of outputs) {
+      ev.formData.append("outputs", output);
+    }
+  });
 
   button.classList.remove(
     "cursor-not-allowed",

--- a/assets/src/scripts/_form-setup.js
+++ b/assets/src/scripts/_form-setup.js
@@ -7,9 +7,7 @@ const formSetup = () => {
 
   form.addEventListener("formdata", (ev) => {
     // TODO: get from signal
-    for (const [output] of outputs) {
-      ev.formData.append("outputs", output);
-    }
+    outputs.forEach((_, k) => ev.formData.append("outputs", k));
   });
 
   button.classList.remove(


### PR DESCRIPTION
For now, it just posts all of them. Future changes will allow selection.

The backend validates and then generates a zip with just files the
requested.

The JS works in the simplest way possible, inserting the files when the
form is submitted. This plays very nicely with CSRF and
Content-Disposition downloads.
