### PR TITLE
Eslint fixes

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -19,6 +19,9 @@ module.exports = {
     ecmaVersion: "latest",
     sourceType: "module",
   },
+  settings: {
+    "import/core-modules": ["electron", "portfinder"],
+  },
   rules: {
     "prettier/prettier": "error",
     "import/order": [

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,13 @@ jobs:
         with:
           python-version: "3.10"
           install-just: true
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: "npm"
+          cache-dependency-path: "**/package-lock.json"
+      - name: Install dependencies
+        run: npm install eslint
       - name: Check formatting, linting and import sorting
         run: just check
 

--- a/assets/src/scripts/_file-click.js
+++ b/assets/src/scripts/_file-click.js
@@ -108,10 +108,8 @@ const fileClick = async ({ fileName, metadata, url }) => {
 
   button.addEventListener("click", () => {
     if (approvedFiles.value.includes(fileName)) {
-      console.log(`removing ${fileName} from release`);
       approvedFiles.value = approvedFiles.value.filter((o) => o !== fileName);
     } else {
-      console.log(`approving ${fileName} from release`);
       approvedFiles.value = approvedFiles.value.concat([fileName]);
     }
     toggleButton();

--- a/assets/src/scripts/_files-list.js
+++ b/assets/src/scripts/_files-list.js
@@ -27,7 +27,6 @@ const fileList = () => {
   });
 
   effect(() => {
-    console.log(approvedFiles.value);
     outputs.forEach((_, name) => {
       const el = container.querySelector(`#list_${name}`);
       if (approvedFiles.value.includes(name)) {

--- a/assets/src/scripts/_form-setup.js
+++ b/assets/src/scripts/_form-setup.js
@@ -44,7 +44,6 @@ const formSetup = () => {
   });
 
   form.addEventListener("formdata", (ev) => {
-    console.log(`adding ${approvedFiles.value.length} files to form data`);
     approvedFiles.value.forEach((output) =>
       ev.formData.append("outputs", output)
     );

--- a/assets/src/scripts/_utils.js
+++ b/assets/src/scripts/_utils.js
@@ -31,7 +31,7 @@ export function csvStringToTable(csvString, el) {
   table += `</tbody>`;
   table += `</table>`;
 
-  el.innerHTML = table;
+  el.innerHTML = table; // eslint-disable-line
 }
 
 export const isCsv = (ext) => ext.toLowerCase() === "csv";

--- a/justfile
+++ b/justfile
@@ -121,6 +121,7 @@ ruff *args=".": devenv
 
 # run the various dev checks but does not change any files
 check: black ruff
+    npm run lint
 
 
 # fix formatting and import sort ordering


### PR DESCRIPTION
I accidentally noticed that `npm lint` was throwing up some errors and then realised we aren't running it as part of our standard checks. This change fixes that and then fixes/ignores the resulting linting errors.