### PR TITLE
Parse and transform ACRO JSON into something more useful.

### DIFF
--- a/assets/src/scripts/_file-click.js
+++ b/assets/src/scripts/_file-click.js
@@ -4,12 +4,7 @@ import { csvStringToTable, getFileExt, isCsv, isImg } from "./_utils";
 
 const fileContentElement = document.getElementById("fileContent");
 
-const splitTextToList = ({ splitter, text }) =>
-  text
-    .split(splitter)
-    .filter((i) => i !== " " && i.length)
-    .map((i) => `<li>${i}</li>`)
-    .join("");
+const toList = ({ list }) => list.map((i) => `<li>${i}</li>`).join("");
 
 const createCsvTableElement = (data) => {
   csvStringToTable(data, fileContentElement);
@@ -35,7 +30,7 @@ const fileClick = async ({ fileName, metadata, url }) => {
   // Set the file values
   openFile.value = {
     fileName,
-    ext: getFileExt(metadata.output),
+    ext: getFileExt(metadata.path),
     url,
     metadata,
   };
@@ -49,19 +44,13 @@ const fileClick = async ({ fileName, metadata, url }) => {
   fileMetadata.innerHTML = `
     <ul>
       <li><strong>Summary:</strong>
-        <ul>${splitTextToList({
-          splitter: "; ",
-          text: metadata.summary,
-        })}</ul>
+        <ul>${toList({ list: metadata.summary })}</ul>
       </li>
       ${
         metadata.comments
           ? `
             <li class="mt-2"><strong>Comments:</strong>
-              <ul>${splitTextToList({
-                splitter: ", ",
-                text: metadata.comments,
-              })}</ul>
+              <ul>${toList({ list: metadata.comments })}</ul>
             </li>
           `
           : ""

--- a/sacro/transform.py
+++ b/sacro/transform.py
@@ -1,0 +1,54 @@
+import json
+import re
+from datetime import datetime
+
+
+TYPE = re.compile(r".*acro.(\w+)\(.*")
+# example "2023-06-23-11472054",
+DATE_FORMAT = "%Y-%m-%d-%H%M%S%f"
+
+
+def transform_acro_metadata(raw_metadata):
+    """Parse and transform current ACRO JSON format into richer more useful format."""
+    transformed = {}
+
+    for name, metadata in raw_metadata.items():
+        display_name = name
+        raw_ts = metadata.get("timestamp")
+        if raw_ts:
+            display_name = name[: -(len(raw_ts) + 1)]
+        status, *summary = (
+            s.strip()
+            for s in metadata.get("summary", "unknown").split(";")
+            if s.strip()
+        )
+        output_type = metadata.get("command", "unknown")
+        if output_type not in ("unknown", "custom"):
+            match = TYPE.search(output_type)
+            if match:
+                output_type = match.group(1)
+            else:
+                output_type = "unknown"
+        outcome = metadata.get("outcome", {})
+        new = {
+            "name": name,
+            "display_name": display_name,
+            "type": output_type,
+            "status": status,
+            "summary": summary,
+            "outcome": json.loads(outcome) if isinstance(outcome, str) else outcome,
+            "path": metadata.get("output"),
+            "command": metadata.get("command"),
+            "comments": [
+                c.strip() for c in metadata.get("comments", "").split(",") if c.strip()
+            ],
+            "timestamp": None,
+        }
+
+        if raw_ts:
+            # current, the timestamps we get are naive, so we preserve that
+            new["timestamp"] = datetime.strptime(raw_ts, DATE_FORMAT).isoformat()
+
+        transformed[name] = new
+
+    return transformed

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,0 +1,96 @@
+import json
+
+import pytest
+
+from sacro import transform
+
+
+def test_minimal():
+    minimal = {"test": {}}
+
+    assert transform.transform_acro_metadata(minimal) == {
+        "test": {
+            "name": "test",
+            "display_name": "test",
+            "type": "unknown",
+            "status": "unknown",
+            "summary": [],
+            "outcome": {},
+            "path": None,
+            "command": None,
+            "comments": [],
+            "timestamp": None,
+        }
+    }
+
+
+def test_outcome_parsing():
+    outcome = {"foo": "bar"}
+
+    json_outcome = transform.transform_acro_metadata({"test": {"outcome": outcome}})
+    assert json_outcome["test"]["outcome"] == outcome
+    # stringified
+    str_outcome = transform.transform_acro_metadata(
+        {"test": {"outcome": json.dumps(outcome)}}
+    )
+    assert str_outcome["test"]["outcome"] == outcome
+
+
+def test_timestamp_parsing():
+    ts = "2023-01-01-12345612"
+    name = f"test_{ts}"
+    # note that the timestamps we currently get from acro are naive.
+    iso = "2023-01-01T12:34:56.120000"
+
+    test = {f"test_{ts}": {"timestamp": ts}}
+
+    assert transform.transform_acro_metadata(test) == {
+        name: {
+            "name": name,
+            "display_name": "test",
+            "type": "unknown",
+            "status": "unknown",
+            "summary": [],
+            "outcome": {},
+            "path": None,
+            "command": None,
+            "comments": [],
+            "timestamp": iso,
+        }
+    }
+
+
+@pytest.mark.parametrize(
+    "command,expected",
+    [
+        ("foo = acro.crosstab(...)", "crosstab"),
+        ("foo = acro.pivot_table(...)", "pivot_table"),
+        ("foo = acro.ols()...)", "ols"),
+        ("foo = acro.olsr()...)", "olsr"),
+        ("foo = acro.logit()...)", "logit"),
+        ("foo = acro.progit()...)", "progit"),
+        ("foo = ...", "unknown"),
+    ],
+)
+def test_type_parsing(command, expected):
+    test = {"test": {"command": command}}
+    transformed = transform.transform_acro_metadata(test)
+    assert transformed["test"]["type"] == expected
+
+
+def test_status_parsing():
+    transformed = transform.transform_acro_metadata(
+        {"test": {"summary": "pass; other; info"}}
+    )
+    assert transformed["test"]["status"] == "pass"
+    assert transformed["test"]["summary"] == ["other", "info"]
+
+    transformed = transform.transform_acro_metadata(
+        {"test": {"summary": "fail; other; info"}}
+    )
+    assert transformed["test"]["status"] == "fail"
+    assert transformed["test"]["summary"] == ["other", "info"]
+
+    transformed = transform.transform_acro_metadata({"test": {"summary": "review"}})
+    assert transformed["test"]["status"] == "review"
+    assert transformed["test"]["summary"] == []

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -94,3 +94,8 @@ def test_status_parsing():
     transformed = transform.transform_acro_metadata({"test": {"summary": "review"}})
     assert transformed["test"]["status"] == "review"
     assert transformed["test"]["summary"] == []
+
+
+def test_comment_parsing():
+    transformed = transform.transform_acro_metadata({"test": {"comments": ",1,,2,"}})
+    assert transformed["test"]["comments"] == ["1", "2"]


### PR DESCRIPTION
This make the JSON easier to consume in the UI code, and also provides a
single tested point to parse data or handle changes in format.

The only b/w incompat was renaming the filed containing the file path
from `output` to `path`, and the name output seems a little overused
already.

Fixes #99
