### PR TITLE
Ensure all python files are picked up by Coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,13 @@ branch = true
 dynamic_context = "test_function"
 omit = [
   ".venv/*",
+  "sacro/__main__.py",
+  "sacro/asgi.py",
+  "sacro/middleware.py",
+]
+source = [
+  "sacro",
+  "tests",
 ]
 
 [tool.coverage.report]


### PR DESCRIPTION
Without the source option in pyproject.toml, the Coverage tool doesn't pick up all python files. Any that were previously missed and that don't currently have test coverage have been explicitly omitted for now.