### PR TITLE
Add sacro status and type to the sidebar

### DIFF
--- a/assets/src/scripts/_file-click.js
+++ b/assets/src/scripts/_file-click.js
@@ -76,7 +76,7 @@ const fileClick = async ({ fileName, metadata, url }) => {
             <strong>Review:</strong>
             <ul>
               <button class="approve inline-flex items-center justify-center rounded-md shadow-sm transition-buttons duration-200 px-4 py-2 text-sm font-medium bg-blue-600 text-white hover:bg-blue-700 focus:bg-blue-700 focus:ring-blue-500 focus:ring-offset-white" data-cy="approve">Approve</button>
-              <button class="reset inline-flex items-center justify-center rounded-md shadow-sm transition-buttons duration-200 px-4 py-2 text-sm font-medium bg-slate-300 text-white hover:bg focus:bg-slate-500 focus:ring-slate-400 focus:ring-offset-white">Reset</button>
+              <button class="reset inline-flex items-center justify-center rounded-md shadow-sm transition-buttons duration-200 px-4 py-2 text-sm font-medium bg-slate-600 text-white hover:bg focus:bg-slate-500 focus:ring-slate-400 focus:ring-offset-white">Reset</button>
               <button class="reject  inline-flex items-center justify-center rounded-md shadow-sm transition-buttons duration-200 px-4 py-2 text-sm font-medium bg-red-600 text-white hover:bg-red-700 focus:bg-red-700 focus:ring-red-500 focus:ring-offset-white">Reject</button>
             </ul>
           </li>
@@ -89,9 +89,13 @@ const fileClick = async ({ fileName, metadata, url }) => {
   const resetButton = fileMetadata.querySelector("button.reset");
   const rejectButton = fileMetadata.querySelector("button.reject");
 
-  approveButton.addEventListener("click", () => setReviewState(fileName, true));
-  resetButton.addEventListener("click", () => setReviewState(fileName, null));
-  rejectButton.addEventListener("click", () => setReviewState(fileName, false));
+  approveButton.addEventListener("click", () =>
+    setReviewState(fileName, "approved")
+  );
+  resetButton.addEventListener("click", () => setReviewState(fileName, "none"));
+  rejectButton.addEventListener("click", () =>
+    setReviewState(fileName, "rejected")
+  );
 
   if (isCsv(openFile.value.ext)) {
     const data = await fileLoader(openFile);

--- a/assets/src/scripts/_file-click.js
+++ b/assets/src/scripts/_file-click.js
@@ -89,13 +89,9 @@ const fileClick = async ({ fileName, metadata, url }) => {
   const resetButton = fileMetadata.querySelector("button.reset");
   const rejectButton = fileMetadata.querySelector("button.reject");
 
-  approveButton.addEventListener("click", () =>
-    setReviewState(fileName, "approved")
-  );
-  resetButton.addEventListener("click", () => setReviewState(fileName, "none"));
-  rejectButton.addEventListener("click", () =>
-    setReviewState(fileName, "rejected")
-  );
+  approveButton.addEventListener("click", () => setReviewState(fileName, true));
+  resetButton.addEventListener("click", () => setReviewState(fileName, null));
+  rejectButton.addEventListener("click", () => setReviewState(fileName, false));
 
   if (isCsv(openFile.value.ext)) {
     const data = await fileLoader(openFile);

--- a/assets/src/scripts/_files-list.js
+++ b/assets/src/scripts/_files-list.js
@@ -30,10 +30,13 @@ const fileList = () => {
     effect(() => {
       outputs.forEach((_, name) => {
         const state = approvedFiles.value.get(name);
-        if (state === null) return;
 
         if (fileName === name) {
-          el.setAttribute("data-review-status", state);
+          if (state === null) {
+            el.setAttribute("data-review-status", "none");
+          } else {
+            el.setAttribute("data-review-status", state);
+          }
         }
       });
     });

--- a/assets/src/scripts/_files-list.js
+++ b/assets/src/scripts/_files-list.js
@@ -5,43 +5,37 @@ import { approvedFiles } from "./_signals";
 
 const fileList = () => {
   const container = document.getElementById("filesList");
-  const children = [...container.children];
+  const fileListItems = [...container.querySelectorAll("li")];
 
   // add click handler to each list item
-  children.forEach((el) => {
-    const fileName = el.id;
+  fileListItems.forEach((el) => {
+    const fileName = el.getAttribute("data-file-name");
     const metadata = outputs.get(fileName);
 
     // get the URL and strip off the leading #
-    const url = el.firstElementChild.getAttribute("href").replace("#", "");
+    const url = el.querySelector("a").getAttribute("href").replace("#/", "");
 
     // toggle selected state for the file list
     el.addEventListener("click", () => {
       handleFileClick({ fileName, metadata, url });
 
       // clear selected class from all items in the list
-      children.forEach((e) => e.classList.remove("selected"));
+      fileListItems.forEach((e) => e.classList.remove("bg-blue-50"));
 
       // set selected class on this list item
-      el.classList.add("selected");
+      el.classList.add("bg-blue-50");
     });
-  });
 
-  // toggle css changes on state change
-  effect(() => {
-    outputs.forEach((_, name) => {
-      const el = container.querySelector(`#${name}`);
-      const state = approvedFiles.value.get(name);
-      if (state === null) {
-        el.classList.add("state_unknown");
-        el.classList.remove("state_approved", "state_rejected");
-      } else if (state) {
-        el.classList.add("state_approved");
-        el.classList.remove("state_unknown", "state_rejected");
-      } else {
-        el.classList.add("state_rejected");
-        el.classList.remove("state_unknown", "state_approved");
-      }
+    // toggle icon changes on state change
+    effect(() => {
+      outputs.forEach((_, name) => {
+        const state = approvedFiles.value.get(name);
+        if (state === null) return;
+
+        if (fileName === name) {
+          el.setAttribute("data-review-status", state);
+        }
+      });
     });
   });
 };

--- a/assets/src/styles/main.css
+++ b/assets/src/styles/main.css
@@ -36,14 +36,5 @@ body > main {
 }
 
 li.selected {
-  background-color: grey;
-
-}
-
-li.state_approved {
-  background-color: lightgreen;
-}
-
-li.state_rejected {
-  background-color: lightcoral;
+  background-color: lightgrey;
 }

--- a/sacro/templates/components.yaml
+++ b/sacro/templates/components.yaml
@@ -3,6 +3,12 @@ components:
   card: "components/card.html"
 
   icon_breadcrumb_arrow: "icons/breadcrumb-arrow.svg"
+  icon_check: "icons/check.svg"
   icon_document_outline: "icons/document-outline.svg"
-  icon_folder_outline: "icons/folder-outline.svg"
+  icon_file: "icons/file.svg"
+  icon_file_unknown: "icons/file-unknown.svg"
+  icon_file_x: "icons/file-x.svg"
   icon_folder_open_outline: "icons/folder-open-outline.svg"
+  icon_folder_outline: "icons/folder-outline.svg"
+  icon_x_mark: "icons/x-mark.svg"
+  icon_question_mark_circle: "icons/question-mark-circle.svg"

--- a/sacro/templates/icons/check.svg
+++ b/sacro/templates/icons/check.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="{{ class }}" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" height="24" width="24">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+</svg>

--- a/sacro/templates/icons/file-unknown.svg
+++ b/sacro/templates/icons/file-unknown.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="{{ class }}" width="24" height="24" viewBox="0 0 24 24" stroke-width="1" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+   <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+   <path d="M14 3v4a1 1 0 0 0 1 1h4"></path>
+   <path d="M17 21h-10a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2z"></path>
+   <path d="M12 17v.01"></path>
+   <path d="M12 14a1.5 1.5 0 1 0 -1.14 -2.474"></path>
+</svg>

--- a/sacro/templates/icons/file-x.svg
+++ b/sacro/templates/icons/file-x.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="{{ class }}" width="24" height="24" viewBox="0 0 24 24" stroke-width="1" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+   <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+   <path d="M14 3v4a1 1 0 0 0 1 1h4"></path>
+   <path d="M17 21h-10a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2z"></path>
+   <path d="M10 12l4 4m0 -4l-4 4"></path>
+</svg>

--- a/sacro/templates/icons/file.svg
+++ b/sacro/templates/icons/file.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="{{ class }}" width="20" height="20" viewBox="0 0 24 24" stroke-width="1" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+   <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+   <path d="M14 3v4a1 1 0 0 0 1 1h4"></path>
+   <path d="M17 21h-10a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2z"></path>
+</svg>

--- a/sacro/templates/icons/question-mark-circle.svg
+++ b/sacro/templates/icons/question-mark-circle.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="{{ class }}" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" height="24" width="24">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9 5.25h.008v.008H12v-.008z" />
+</svg>

--- a/sacro/templates/icons/x-mark.svg
+++ b/sacro/templates/icons/x-mark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="{{ class }}" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" height="24" width="24">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+</svg>

--- a/sacro/templates/index.html
+++ b/sacro/templates/index.html
@@ -49,8 +49,8 @@
             text-fuchsia-900
             {% endif %}
 
-            data-[review-status=approved]:bg-green-100/50
-            data-[review-status=rejected]:bg-red-100/50
+            data-[review-status=true]:bg-green-100/50
+            data-[review-status=false]:bg-red-100/50
           "
 
           data-file-name="{{ file.name }}"
@@ -96,11 +96,11 @@
                   <span class="sr-only">Not yet reviewed</span>
                   <svg class="h-5 w-5"></svg>
                 </span>
-                <span class="hidden group-data-[review-status=approved]:block">
+                <span class="hidden group-data-[review-status=true]:block">
                   <span class="sr-only">Approved</span>
                   {% icon_check class="h-5 w-5 text-green-600" %}
                 </span>
-                <span class="hidden group-data-[review-status=rejected]:block">
+                <span class="hidden group-data-[review-status=false]:block">
                   <span class="sr-only">Rejected</span>
                   {% icon_x_mark class="h-5 w-5 text-red-600" %}
                 </span>

--- a/sacro/templates/index.html
+++ b/sacro/templates/index.html
@@ -34,17 +34,79 @@
     </header>
 
     <aside class="overflow-y-scroll bg-white border-r border-zinc-200 py-2">
-      <ul class="text-sm h-full" id="filesList" data-cy="filesList">
-        {% for name, url in content_urls.items %}
-        <li id="{{ name }}" class="relative z-10">
-          <a
-            class="py-1 px-2 flex justify-start items-center gap-1 leading-tight hover:bg-blue-100/50 text-blue-800"
-            data-file="link"
-            href="#{{ url }}"
-          >
-            {% icon_document_outline class="h-4 w-4 min-w-[1rem] text-zinc-500" %}
-            <span class="break-all" data-file="name">{{ name }}</span>
-          </a>
+      <h2 id="fileListHeader" class="sr-only">File list</h2>
+      <ul class="text-sm h-full flex flex-col gap-y-0.5" aria-label="List of files" id="filesList" data-cy="filesList">
+        {% for file in files %}
+        <li
+          aria-label="File: {{ file.name }}"
+          class="
+            relative group py-0.5 px-1 hover:bg-slate-50
+            {% if file.status == "fail" %}
+            text-red-800
+            {% elif file.status == "pass" %}
+            text-blue-800
+            {% elif file.status == "review" %}
+            text-fuchsia-900
+            {% endif %}
+
+            data-[review-status=approved]:bg-green-100/50
+            data-[review-status=rejected]:bg-red-100/50
+          "
+
+          data-file-name="{{ file.name }}"
+          data-review-status="none"
+        >
+          <dl class="flex flex-row gap-x-2 items-center" aria-label="File information">
+            <div class="order-2">
+              <dt class="sr-only">File name:</dt>
+              <dd>
+                <a
+                  href="#{{ file.url }}"
+                  class="
+                    before:absolute before:inset-0 before:w-full before:h-full before:z-0
+                  "
+                >
+                  <span class="z-10 relative">
+                    {{ file.name }}
+                  </span>
+                </a>
+              </dd>
+            </div>
+            <div class="order-1">
+              <dt class="sr-only">ACRO status:</dt>
+              <dd>
+                <span class="sr-only">{{ file.status }}</span>
+                {% if file.status == "fail" %}
+                {% icon_file_x class="h-5 w-5 stroke-red-700" %}
+                {% elif file.status == "pass" %}
+                {% icon_file class="h-5 w-5 stroke-blue-700" %}
+                {% elif file.status == "review" %}
+                {% icon_file_unknown class="h-5 w-5 stroke-fuchsia-700" %}
+                {% endif %}
+              </dd>
+            </div>
+            <div class="order-3 ml-auto">
+              <dt class="sr-only">File type:</dt>
+              <dd>{{ file.type }}</dd>
+            </div>
+            <div class="order-4">
+              <dt class="sr-only">Review status:</dt>
+              <dd>
+                <span class="hidden group-data-[review-status=none]:block">
+                  <span class="sr-only">Not yet reviewed</span>
+                  <svg class="h-5 w-5"></svg>
+                </span>
+                <span class="hidden group-data-[review-status=approved]:block">
+                  <span class="sr-only">Approved</span>
+                  {% icon_check class="h-5 w-5 text-green-600" %}
+                </span>
+                <span class="hidden group-data-[review-status=rejected]:block">
+                  <span class="sr-only">Rejected</span>
+                  {% icon_x_mark class="h-5 w-5 text-red-600" %}
+                </span>
+              </dd>
+            </div>
+          </dl>
         </li>
         {% endfor %}
       </ul>

--- a/sacro/views.py
+++ b/sacro/views.py
@@ -83,11 +83,25 @@ def index(request):
         data = {"path": "outputs/results.json"}
 
     outputs = get_outputs(data)
+
+    # build up all the bits we need for sidebar's context as a single list
+    files = [
+        {
+            "name": name,
+            "status": data["status"],
+            "type": f"{data['properties'].get('method', '')} {data['type']}".strip(),
+            "url": reverse_with_params(
+                {"path": str(outputs.path), "name": name}, "contents"
+            ),
+        }
+        for name, data in outputs.items()
+    ]
+
     return TemplateResponse(
         request,
         "index.html",
         context={
-            "content_urls": outputs.content_urls,
+            "files": files,
             "outputs": outputs.as_dict(),
         },
     )


### PR DESCRIPTION
Display various bits of context for each file in the files list to help a user skim through them.

The columns are, from left to right, are:
* ACRO status
* File name
* File type (a combination of method, if there is one, and type)
* Review status if the file has one

![](https://p198.p4.n0.cdn.getcloudapp.com/items/Jrue1OvX/3e9c1974-ca34-40ed-9d43-fe5f00d16f28.jpg?v=dff4cad0f5f2144a25e9ed747e38549f)

Fix: #111 