### PR TITLE
Remove auth app and switch to cookie sessions

### DIFF
--- a/sacro/settings.py
+++ b/sacro/settings.py
@@ -41,8 +41,8 @@ INSTALLED_APPS = [
     "django_extensions",
     "django_vite",
     "slippers",
-    "django.contrib.auth",
-    "django.contrib.contenttypes",
+    # "django.contrib.auth",
+    # "django.contrib.contenttypes",
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
@@ -55,10 +55,13 @@ MIDDLEWARE = [
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
-    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    # "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
+
+SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
+SESSION_COOKIE_HTTPONLY = True
 
 # add dev tools only when needed
 if DEBUG:  # pragma: no cover
@@ -80,7 +83,7 @@ TEMPLATES = [
             "context_processors": [
                 "django.template.context_processors.debug",
                 "django.template.context_processors.request",
-                "django.contrib.auth.context_processors.auth",
+                # "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
             ],
             "builtins": [


### PR DESCRIPTION
This removes the need for migrations alltogether.

And we still have sessions and anything based on sessions
(e.g. messages).

I have left the auth/contentypes stuff in settings.py commented out, so
this is quick to revert if we need to.
