### PR TITLE
Add the output's timestamp in a human readable format

### DIFF
--- a/assets/src/scripts/_file-click.js
+++ b/assets/src/scripts/_file-click.js
@@ -39,12 +39,24 @@ const fileClick = async ({ fileName, metadata, url }) => {
   document.querySelector("#openFileName h2").textContent =
     openFile.value.fileName;
 
+  // Create a human readable date from the timestamp
+  const createdAt = new Date(metadata.timestamp).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "numeric",
+    minute: "numeric",
+  });
+
   // Set the metadata
   const fileMetadata = document.getElementById("fileMetadata");
   fileMetadata.innerHTML = `
     <ul>
       <li><strong>Summary:</strong>
         <ul>${metadata.summary}</ul>
+      </li>
+      <li class="mt-2"><strong>Created:</strong>
+        <ul title="${metadata.timestamp}">${createdAt}</ul>
       </li>
       ${
         metadata.comments

--- a/assets/src/scripts/_file-click.js
+++ b/assets/src/scripts/_file-click.js
@@ -40,7 +40,7 @@ const fileClick = async ({ fileName, metadata, url }) => {
     openFile.value.fileName;
 
   // Create a human readable date from the timestamp
-  const createdAt = new Date(metadata.timestamp).toLocaleDateString(undefined, {
+  const createdAt = new Date(metadata.timestamp).toLocaleDateString("en-GB", {
     year: "numeric",
     month: "long",
     day: "numeric",


### PR DESCRIPTION
The original timestamp has been preserved via the title attribute so users can see it on hover.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/6quJ80XZ/2ec8375b-55b3-45e9-a4fe-feb3f8f41c27.jpg?v=8cb31d9734dcd3472a16551dc0852546)

Fix: #113 