### PR TITLE
Submitt review as structured JSON.

### DIFF
--- a/assets/src/scripts/_form-setup.js
+++ b/assets/src/scripts/_form-setup.js
@@ -43,12 +43,19 @@ const formSetup = () => {
 
   effect(() => setButtonState(isReviewComplete()));
 
-  form.addEventListener("formdata", (e) => {
-    const reviewedApprovedFiles = Object.keys(approvedFiles.value).filter(
-      (key) => approvedFiles.value[key]?.approved === true
+  form.addEventListener("formdata", (ev) => {
+    const data = Object.fromEntries(
+      [...approvedFiles.value.keys()].map((i) => [
+        i,
+        {
+          state: approvedFiles.value[i].approved,
+          comment: "",
+        },
+      ])
     );
-
-    reviewedApprovedFiles.map((file) => e.formData.append("outputs", file));
+    // serialize the review state as a JSON string in the form submission
+    // We tunnel JSON via default form encoding because of Django CSRF, mainly
+    ev.formData.set("review", JSON.stringify(data));
   });
 };
 

--- a/sacro/views.py
+++ b/sacro/views.py
@@ -134,9 +134,12 @@ def review(request):
     # we load the path from the querystring, even though this is a post request
     outputs = get_outputs(request.GET)
 
-    approved_outputs = request.POST.getlist("outputs")
-    if not approved_outputs:
-        return HttpResponseBadRequest("no outputs specified")
+    raw_json = request.POST.get("review")
+    if not raw_json:
+        return HttpResponseBadRequest("no review data ")
+
+    review = json.loads(raw_json)
+    approved_outputs = [k for k, v in review.items() if v["state"] is True]
 
     unrecognize_outputs = [o for o in approved_outputs if o not in outputs]
     if unrecognize_outputs:


### PR DESCRIPTION
We use a JSON string to pass the review data via teh form to the
endpoint. We do this to work Django's CSRF, and to keep the form
submission standard HTML form, which is the only way to get a download
dialog (cannot prompt for that via JS easily).
