### PR TITLE
Per-file reviewer comments

### DIFF
--- a/assets/src/scripts/_file-click.js
+++ b/assets/src/scripts/_file-click.js
@@ -93,23 +93,30 @@ const fileClick = async ({ fileName, metadata, url }) => {
         <ul class="mt-2">
           <li>
             <strong>Review:</strong>
-            <ul>
-              <button class="approve inline-flex items-center justify-center rounded-md shadow-sm transition-buttons duration-200 px-4 py-2 text-sm font-medium ${approveButtonStyles}" data-cy="approve">Approve</button>
-              <button class="reset inline-flex items-center justify-center rounded-md shadow-sm transition-buttons duration-200 px-4 py-2 text-sm font-medium bg-slate-600 text-white hover:bg focus:bg-slate-500 focus:ring-slate-400 focus:ring-offset-white">Reset</button>
-              <button class="reject inline-flex items-center justify-center rounded-md shadow-sm transition-buttons duration-200 px-4 py-2 text-sm font-medium ${rejectButtonStyles}">Reject</button>
-            </ul>
+            <div class="flex flex-row">
+              <button class="approve inline-flex items-center justify-center rounded-l-md shadow-sm transition-buttons duration-200 px-4 py-2 text-sm font-medium ${approveButtonStyles}" data-cy="approve">Approve</button>
+              <button class="reset inline-flex items-center justify-center shadow-sm transition-buttons duration-200 px-4 py-2 text-sm font-medium bg-slate-600 text-white hover:bg focus:bg-slate-500 focus:ring-slate-400 focus:ring-offset-white">Reset</button>
+              <button class="reject inline-flex items-center justify-center rounded-r-md shadow-sm transition-buttons duration-200 px-4 py-2 text-sm font-medium ${rejectButtonStyles}">Reject</button>
+            </div>
           </li>
-          <li>
-            <label for="comments">Review comments on ${fileName}:</label>
-          </li>
-          <li>
-            <textarea type="text" name="comments"
-            class="
-              comments
-              mt-1 block w-full rounded-md border-slate-300 text-slate-900 shadow-sm
-              sm:text-sm
-              focus:border-oxford-500 focus:ring-oxford-500
-              invalid:border-bn-ribbon-600 invalid:ring-bn-ribbon-600 invalid:ring-1"
+          <li class="mt-2">
+            <label
+              class="inline-block font-semibold text-slate-900 cursor-pointer"
+              for="comments"
+            >
+              Review comments on ${fileName}:
+            </label>
+            <textarea
+              class="
+                comments
+                mt-1 block w-full rounded-md border-slate-300 text-slate-900 shadow-sm resize-none
+                sm:text-sm
+                focus:border-oxford-500 focus:ring-oxford-500
+                invalid:border-bn-ribbon-600 invalid:ring-bn-ribbon-600 invalid:ring-1
+              "
+              name="comments"
+              id="comments"
+              type="text"
             >${fileComments.value[fileName]}</textarea>
           </li>
         </ul>

--- a/assets/src/scripts/_file-click.js
+++ b/assets/src/scripts/_file-click.js
@@ -1,5 +1,5 @@
 import fileLoader from "./_file-loader";
-import { openFile, setReviewState } from "./_signals";
+import { openFile, fileComments, setReviewState, setComment } from "./_signals";
 import { csvStringToTable, getFileExt, isCsv, isImg } from "./_utils";
 
 const fileContentElement = document.getElementById("fileContent");
@@ -50,6 +50,13 @@ const fileClick = async ({ fileName, metadata, url }) => {
 
   // Set the metadata
   const fileMetadata = document.getElementById("fileMetadata");
+
+  // define active button styles
+  const approveButtonStyles =
+    "bg-blue-600 text-white hover:bg-blue-700 focus:bg-blue-700 focus:ring-blue-500 focus:ring-offset-white";
+  const rejectButtonStyles =
+    "bg-red-600 text-white hover:bg-red-700 focus:bg-red-700 focus:ring-red-500 focus:ring-offset-white";
+
   fileMetadata.innerHTML = `
     <ul>
       <li><strong>Summary:</strong>
@@ -87,10 +94,23 @@ const fileClick = async ({ fileName, metadata, url }) => {
           <li>
             <strong>Review:</strong>
             <ul>
-              <button class="approve inline-flex items-center justify-center rounded-md shadow-sm transition-buttons duration-200 px-4 py-2 text-sm font-medium bg-blue-600 text-white hover:bg-blue-700 focus:bg-blue-700 focus:ring-blue-500 focus:ring-offset-white" data-cy="approve">Approve</button>
+              <button class="approve inline-flex items-center justify-center rounded-md shadow-sm transition-buttons duration-200 px-4 py-2 text-sm font-medium ${approveButtonStyles}" data-cy="approve">Approve</button>
               <button class="reset inline-flex items-center justify-center rounded-md shadow-sm transition-buttons duration-200 px-4 py-2 text-sm font-medium bg-slate-600 text-white hover:bg focus:bg-slate-500 focus:ring-slate-400 focus:ring-offset-white">Reset</button>
-              <button class="reject  inline-flex items-center justify-center rounded-md shadow-sm transition-buttons duration-200 px-4 py-2 text-sm font-medium bg-red-600 text-white hover:bg-red-700 focus:bg-red-700 focus:ring-red-500 focus:ring-offset-white">Reject</button>
+              <button class="reject inline-flex items-center justify-center rounded-md shadow-sm transition-buttons duration-200 px-4 py-2 text-sm font-medium ${rejectButtonStyles}">Reject</button>
             </ul>
+          </li>
+          <li>
+            <label for="comments">Review comments on ${fileName}:</label>
+          </li>
+          <li>
+            <textarea type="text" name="comments"
+            class="
+              comments
+              mt-1 block w-full rounded-md border-slate-300 text-slate-900 shadow-sm
+              sm:text-sm
+              focus:border-oxford-500 focus:ring-oxford-500
+              invalid:border-bn-ribbon-600 invalid:ring-bn-ribbon-600 invalid:ring-1"
+            >${fileComments.value[fileName]}</textarea>
           </li>
         </ul>
       </li>
@@ -100,10 +120,62 @@ const fileClick = async ({ fileName, metadata, url }) => {
   const approveButton = fileMetadata.querySelector("button.approve");
   const resetButton = fileMetadata.querySelector("button.reset");
   const rejectButton = fileMetadata.querySelector("button.reject");
+  const commentInput = fileMetadata.querySelector("textarea.comments");
+
+  const checkComment = (button, activeStyles, comment) => {
+    // if no comment, ensure button disabled. Other was ensure is enabled
+    if (comment.trim() === "") {
+      // ensure button is disabled
+      if (!button.disabled) {
+        button.disabled = true; // eslint-disable-line no-param-reassign
+        button.classList.add(
+          "cursor-not-allowed",
+          "bg-slate-300",
+          "text-slate-800"
+        );
+        button.classList.remove(...activeStyles.split(/ +/));
+        button.setAttribute("title", "You must enter a comment first");
+      }
+    } else if (button.disabled) {
+      // make sure button is enabled
+      button.disabled = false; // eslint-disable-line no-param-reassign
+      button.classList.remove(
+        "cursor-not-allowed",
+        "bg-slate-300",
+        "text-slate-800"
+      );
+      button.classList.add(...activeStyles.split(/ +/));
+      button.setAttribute("title", "");
+    }
+  };
+
+  const requireCommentButtons = [];
+
+  if (metadata.status === "review") {
+    // custom outputs require a comment either way
+    requireCommentButtons.push([approveButton, approveButtonStyles]);
+    requireCommentButtons.push([rejectButton, rejectButtonStyles]);
+  } else if (metadata.status === "fail") {
+    // if ACRO passed, require a comment to approve it
+    requireCommentButtons.push([approveButton, approveButtonStyles]);
+  } else if (metadata.status === "pass") {
+    // if ACRO passed, require a comment to reject it
+    requireCommentButtons.push([rejectButton, rejectButtonStyles]);
+  }
+
+  requireCommentButtons.forEach(([b, cls]) =>
+    checkComment(b, cls, commentInput.value)
+  );
 
   approveButton.addEventListener("click", () => setReviewState(fileName, true));
   resetButton.addEventListener("click", () => setReviewState(fileName, null));
   rejectButton.addEventListener("click", () => setReviewState(fileName, false));
+  commentInput.addEventListener("keyup", () => {
+    setComment(fileName, commentInput.value);
+    requireCommentButtons.forEach(([b, cls]) =>
+      checkComment(b, cls, commentInput.value)
+    );
+  });
 
   if (isCsv(openFile.value.ext)) {
     const data = await fileLoader(openFile);

--- a/assets/src/scripts/_form-setup.js
+++ b/assets/src/scripts/_form-setup.js
@@ -1,6 +1,6 @@
 import { effect } from "@preact/signals";
 import { reviewUrl } from "./_data";
-import { approvedFiles, isReviewComplete } from "./_signals";
+import { approvedFiles, fileComments, isReviewComplete } from "./_signals";
 
 const formSetup = () => {
   const form = document.querySelector("#approveForm");
@@ -49,7 +49,7 @@ const formSetup = () => {
         output,
         {
           state: approvedFiles.value[output].approved,
-          comment: "",
+          comment: fileComments.value[output],
         },
       ])
     );

--- a/assets/src/scripts/_signals.js
+++ b/assets/src/scripts/_signals.js
@@ -5,12 +5,23 @@ import { outputs } from "./_data";
 // Store the file currently visible in the preview
 const openFile = signal();
 
+// initially empty file comments
+const fileComments = signal(
+  Object.fromEntries(Object.keys(outputs).map((output) => [output, ""]))
+);
+
 // Set each output approval status to null
 const approvedFiles = signal(
   Object.fromEntries(
-    Object.entries(outputs).map(([key]) => [key, { approved: null }])
+    Object.entries(outputs).map(([output]) => [output, { approved: null }])
   )
 );
+
+const setComment = (name, comment) => {
+  const newState = { ...fileComments.value };
+  newState[name] = comment;
+  fileComments.value = newState;
+};
 
 const setReviewState = (name, state) => {
   approvedFiles.value = {
@@ -27,4 +38,11 @@ const isReviewComplete = () => {
   return allFilesReviewed;
 };
 
-export { openFile, approvedFiles, setReviewState, isReviewComplete };
+export {
+  openFile,
+  fileComments,
+  approvedFiles,
+  setReviewState,
+  setComment,
+  isReviewComplete,
+};

--- a/assets/src/scripts/_signals.js
+++ b/assets/src/scripts/_signals.js
@@ -18,9 +18,7 @@ const approvedFiles = signal(
 );
 
 const setComment = (name, comment) => {
-  const newState = { ...fileComments.value };
-  newState[name] = comment;
-  fileComments.value = newState;
+  fileComments.value = { ...fileComments.value, [name]: comment };
 };
 
 const setReviewState = (name, state) => {

--- a/sacro/adapters/local_audit.py
+++ b/sacro/adapters/local_audit.py
@@ -4,6 +4,9 @@ import structlog
 logger = structlog.getLogger("audit")
 
 
-def log_release(outputs, username):
-    for output in outputs:
-        logger.info(f"File released by {username}: {output}")
+def log_release(review_data, username):
+    for output, data in review_data.items():
+        verb = "approved" if data["state"] else "rejected"
+        comment = data.get("comment")
+        logger.info(f"Output {output} {verb} by {username}")
+        logger.info(f"Reviewer comment: {comment}")

--- a/sacro/views.py
+++ b/sacro/views.py
@@ -138,12 +138,13 @@ def review(request):
     if not raw_json:
         return HttpResponseBadRequest("no review data ")
 
-    review = json.loads(raw_json)
-    approved_outputs = [k for k, v in review.items() if v["state"] is True]
+    review_data = json.loads(raw_json)
 
-    unrecognize_outputs = [o for o in approved_outputs if o not in outputs]
-    if unrecognize_outputs:
-        return HttpResponseBadRequest(f"invalid output names: {unrecognize_outputs}")
+    approved_outputs = [k for k, v in review_data.items() if v["state"] is True]
+
+    unrecognized_outputs = [o for o in approved_outputs if o not in outputs]
+    if unrecognized_outputs:
+        return HttpResponseBadRequest(f"invalid output names: {unrecognized_outputs}")
 
     in_memory_zf = zipfile.create(outputs, approved_outputs)
 
@@ -151,6 +152,6 @@ def review(request):
     filename = f"{outputs.path.parent.stem}_{outputs.path.stem}.zip"
 
     username = getpass.getuser()
-    local_audit.log_release(approved_outputs, username)
+    local_audit.log_release(review_data, username)
 
     return FileResponse(in_memory_zf, as_attachment=True, filename=filename)

--- a/tests/test_local_audit.py
+++ b/tests/test_local_audit.py
@@ -1,12 +1,18 @@
+from structlog.testing import capture_logs
+
 from sacro.adapters import local_audit
 
 
-def test_log_release_writes_names_of_released_files(capsys):
-    outputs = ["file1", "file2"]
+def test_log_release_logs_all_files_with_comments():
+    review = {
+        "file1": {"state": True, "comment": "comment 1"},
+        "file2": {"state": False, "comment": "comment 2"},
+    }
 
-    local_audit.log_release(outputs, "User")
+    with capture_logs() as logs:
+        local_audit.log_release(review, "User")
 
-    log_output = capsys.readouterr().out
-    assert outputs[0] in log_output
-    assert outputs[1] in log_output
-    assert "User" in log_output
+    assert "file1 approved by User" in logs[0]["event"]
+    assert "comment 1" in logs[1]["event"]
+    assert "file2 rejected by User" in logs[2]["event"]
+    assert "comment 2" in logs[3]["event"]

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -98,7 +98,7 @@ def get_review_url_request(outputs_metadata, review_data):
 
 @pytest.fixture
 def review_data(test_outputs):
-    return {k: {"state": False, "comments": ""} for k in test_outputs.keys()}
+    return {k: {"state": False, "comments": "comment"} for k in test_outputs.keys()}
 
 
 def test_review_success_all_files(test_outputs, review_data):


### PR DESCRIPTION
Adds a basic text box for users to enter comments for each file.

There is some complexity in whether comments are required:

- If ACRO passed, rejecting the output requires a comment.
- If ACRO failed, approving the output requires a comment.
- If ACRO punted (custom), a comment is required either way.

For now, comments are just logged in the audit log.
