### PR TITLE
Store build datetime in a file

### DIFF
--- a/sacro-app/justfile
+++ b/sacro-app/justfile
@@ -15,4 +15,5 @@ run: npm-ci
 build: npm-ci
     #!/bin/bash
     export BUILD_DIR="../build/{{arch()}}-$BUILD_TARGET/release/install/sacro"
+    echo $(date '+%Y-%m-%d %H:%M') > build_date.txt
     npm run build

--- a/sacro-app/justfile
+++ b/sacro-app/justfile
@@ -15,5 +15,5 @@ run: npm-ci
 build: npm-ci
     #!/bin/bash
     export BUILD_DIR="../build/{{arch()}}-$BUILD_TARGET/release/install/sacro"
-    echo $(date '+%Y-%m-%d %H:%M') > build_date.txt
+    echo $(date '+%Y-%m-%d %H:%M') > ${BUILD_DIR}/build_date.txt
     npm run build

--- a/sacro-app/main.js
+++ b/sacro-app/main.js
@@ -1,5 +1,7 @@
 const { app, BrowserWindow } = require("electron");
+const fs = require("fs");
 const process = require("node:process");
+const nodePath = require("path");
 const createWindow = require("./src/create-window");
 
 app.whenReady().then(async () => {
@@ -15,9 +17,16 @@ app.on("window-all-closed", () => {
   if (process.platform !== "darwin") app.quit();
 });
 
+let buildDate = "Not defined";
+const buildDateFile = nodePath.join(__dirname, "build_date.txt");
+if (fs.existsSync(buildDateFile)) {
+  buildDate = fs.readFileSync(buildDateFile);
+  buildDate = `${buildDate}`.trim();
+}
+
 app.setAboutPanelOptions({
   applicationName: "SACRO",
-  applicationVersion: `Version: ${app.getVersion()}`,
+  applicationVersion: `Version ${app.getVersion()} (Build ${buildDate})`,
   credits: "By OpenSAFELY",
   iconPath: "build/icon.png",
 });

--- a/sacro-app/main.js
+++ b/sacro-app/main.js
@@ -1,7 +1,5 @@
 const { app, BrowserWindow } = require("electron");
-const fs = require("fs");
 const process = require("node:process");
-const nodePath = require("path");
 const createWindow = require("./src/create-window");
 
 app.whenReady().then(async () => {
@@ -15,18 +13,4 @@ app.whenReady().then(async () => {
 app.on("window-all-closed", () => {
   // convention on macos is to leave the app running when you close the window
   if (process.platform !== "darwin") app.quit();
-});
-
-let buildDate = "Not defined";
-const buildDateFile = nodePath.join(__dirname, "build_date.txt");
-if (fs.existsSync(buildDateFile)) {
-  buildDate = fs.readFileSync(buildDateFile);
-  buildDate = `${buildDate}`.trim();
-}
-
-app.setAboutPanelOptions({
-  applicationName: "SACRO",
-  applicationVersion: `Version ${app.getVersion()} (Build ${buildDate})`,
-  credits: "By OpenSAFELY",
-  iconPath: "build/icon.png",
 });

--- a/sacro-app/src/main-menu.js
+++ b/sacro-app/src/main-menu.js
@@ -4,6 +4,7 @@ const fs = require("fs");
 const os = require("node:os");
 const nodePath = require("path");
 const querystring = require("querystring");
+const findAppPath = require("./find-app-path");
 
 const mainMenu = (serverUrl) => {
   const menuItems = [
@@ -88,7 +89,11 @@ const mainMenu = (serverUrl) => {
   }
 
   let buildDate = "Not defined";
-  const buildDateFile = nodePath.join(__dirname, "../build_date.txt");
+  const buildDateFile = nodePath.join(
+    nodePath.dirname(findAppPath()),
+    "build_date.txt"
+  );
+  log.info(buildDateFile);
   if (fs.existsSync(buildDateFile)) {
     buildDate = fs.readFileSync(buildDateFile);
     buildDate = `${buildDate}`.trim();

--- a/sacro-app/src/main-menu.js
+++ b/sacro-app/src/main-menu.js
@@ -1,6 +1,8 @@
 const { Menu, dialog, app, BrowserWindow } = require("electron");
 const log = require("electron-log");
+const fs = require("fs");
 const os = require("node:os");
+const nodePath = require("path");
 const querystring = require("querystring");
 
 const mainMenu = (serverUrl) => {
@@ -84,6 +86,20 @@ const mainMenu = (serverUrl) => {
       ],
     });
   }
+
+  let buildDate = "Not defined";
+  const buildDateFile = nodePath.join(__dirname, "../build_date.txt");
+  if (fs.existsSync(buildDateFile)) {
+    buildDate = fs.readFileSync(buildDateFile);
+    buildDate = `${buildDate}`.trim();
+  }
+
+  app.setAboutPanelOptions({
+    applicationName: "SACRO",
+    applicationVersion: `Version ${app.getVersion()} (Build ${buildDate})`,
+    credits: "By OpenSAFELY",
+    iconPath: "build/icon.png",
+  });
 
   return Menu.buildFromTemplate(menuItems);
 };


### PR DESCRIPTION
This build datetime is then used in the About menu to make it easier to see what build of the application they're using.

Fixes #132