### PR TITLE
Don't attempt to open file if cancelled

### DIFF
--- a/sacro-app/src/create-window.js
+++ b/sacro-app/src/create-window.js
@@ -38,13 +38,15 @@ const createWindow = async () => {
     ],
   });
 
-  const qs = querystring.stringify({ path: result.filePaths[0] });
-  const url = `${serverUrl}?${qs}`;
+  if (!result.canceled) {
+    const qs = querystring.stringify({ path: result.filePaths[0] });
+    const url = `${serverUrl}?${qs}`;
 
-  if (serverProcess === null) {
-    win.loadURL(url);
-  } else {
-    waitThenLoad(url, 4000, win);
+    if (serverProcess === null) {
+      win.loadURL(url);
+    } else {
+      waitThenLoad(url, 4000, win);
+    }
   }
 
   if (process.env.DEBUG) {

--- a/sacro-app/src/main-menu.js
+++ b/sacro-app/src/main-menu.js
@@ -23,9 +23,13 @@ const mainMenu = (serverUrl) => {
                 ],
               })
               .then((result) => {
-                const qs = querystring.stringify({ path: result.filePaths[0] });
-                const url = `${serverUrl}?${qs}`;
-                BrowserWindow.getFocusedWindow().loadURL(url);
+                if (!result.canceled) {
+                  const qs = querystring.stringify({
+                    path: result.filePaths[0],
+                  });
+                  const url = `${serverUrl}?${qs}`;
+                  BrowserWindow.getFocusedWindow().loadURL(url);
+                }
               })
               .catch((err) => {
                 log.error(err);


### PR DESCRIPTION
Cancelling the open file dialog is causing errors to appear in the logs, because the request is sent to the server anyway. This change checks whether the dialog was cancelled before deciding whether to make the request.