### PR TITLE
Break the template down into a base and child template

### DIFF
--- a/assets/src/scripts/main.js
+++ b/assets/src/scripts/main.js
@@ -1,4 +1,3 @@
-import "../styles/main.css";
 import formSetup from "./_form-setup";
 import modalSetup from "./_modal-setup";
 import outputList from "./_output-list";

--- a/assets/src/styles/index.css
+++ b/assets/src/styles/index.css
@@ -1,0 +1,29 @@
+body {
+  /* grid-template-rows: max-content max-content 1fr; */
+  grid-template-rows: max-content 1fr;
+  grid-template-columns: minmax(min-content, 1fr) repeat(2, 1fr);
+}
+
+body > aside {
+  grid-column: 1;
+  scrollbar-gutter: stable;
+}
+
+body > main {
+  grid-column: 2 / -1;
+  padding-block: 0.5rem;
+}
+
+.header {
+  align-items: center;
+  background-color: var(--color-white);
+  border-bottom: 1px solid var(--color-zinc-200);
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  padding: 1rem;
+}
+
+li.selected {
+  background-color: lightgrey;
+}

--- a/assets/src/styles/main.css
+++ b/assets/src/styles/main.css
@@ -2,40 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-body {
-  /* grid-template-rows: max-content max-content 1fr; */
-  grid-template-rows: max-content 1fr;
-  grid-template-columns: minmax(min-content, 1fr) repeat(2, 1fr);
-}
-
 body > header {
   grid-column: 1 / -1;
-}
-
-/* body > nav {
-  grid-column: 1 / -1;
-} */
-
-body > aside {
-  grid-column: 1;
-  scrollbar-gutter: stable;
-}
-
-body > main {
-  grid-column: 2 / -1;
-  padding-block: 0.5rem;
-}
-
-.header {
-  align-items: center;
-  background-color: var(--color-white);
-  border-bottom: 1px solid var(--color-zinc-200);
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  padding: 1rem;
-}
-
-li.selected {
-  background-color: lightgrey;
 }

--- a/sacro/templates/base.html
+++ b/sacro/templates/base.html
@@ -1,0 +1,19 @@
+{% load django_vite %}
+{% load static %}
+
+<!DOCTYPE html>
+<html lang="en" class="min-h-screen">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <title>SACRO Outputs Viewer</title>
+
+    {% vite_hmr_client %}
+    {% vite_asset "assets/src/styles/main.css" %}
+    {% block extra_head %}{% endblock %}
+  </head>
+
+  {% block content %}{% endblock %}
+
+</html>

--- a/sacro/templates/components.yaml
+++ b/sacro/templates/components.yaml
@@ -1,6 +1,7 @@
 components:
   button: "components/button.html"
   card: "components/card.html"
+  header: "components/header.html"
   modal: "components/modal.html"
 
   icon_breadcrumb_arrow: "icons/breadcrumb-arrow.svg"

--- a/sacro/templates/components/header.html
+++ b/sacro/templates/components/header.html
@@ -1,0 +1,15 @@
+{% load static %}
+
+<header class="header">
+  <div class="flex gap-x-4 items-center">
+    <img
+      alt="SACRO logo"
+      class="block h-8 w-auto"
+      src="{% static "sacro.svg" %}"
+    >
+    <span class="text-xl font-extrabold text-zinc-800 tracking-tight leading-none">
+      SACRO Outputs Viewer
+    </span>
+  </div>
+  {{ children }}
+</header>

--- a/sacro/templates/index.html
+++ b/sacro/templates/index.html
@@ -1,195 +1,179 @@
+{% extends "base.html" %}
+
 {% load django_vite %}
 {% load static %}
 
-<!DOCTYPE html>
-<html lang="en" class="min-h-screen">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+{% block extra_head %}
+{% vite_asset "assets/src/styles/index.css" %}
+{% vite_asset "assets/src/scripts/main.js" %}
+{% endblock %}
 
-    <title>SACRO Outputs Viewer</title>
-
-    {% vite_hmr_client %}
-    {% vite_asset "assets/src/scripts/main.js" %}
-  </head>
-
+{% block content %}
   <body class="grid h-screen overflow-hidden bg-zinc-100">
-    <header class="header">
-      <div class="flex gap-x-4 items-center">
-        <img
-          alt="SACRO logo"
-          class="block h-8 w-auto"
-          src="{% static "sacro.svg" %}"
-        >
-        <span class="text-xl font-extrabold text-zinc-800 tracking-tight leading-none">
-          SACRO outputs viewer
-        </span>
-      </div>
+    {% #header %}
       {% #button disabled=True id="openModalBtn" type="submit" %}
         Release and download
       {% /button %}
-    </header>
+    {% /header %}
 
-    <aside class="overflow-y-auto bg-white border-r border-zinc-200 py-2">
-      <h2 id="outputListHeader" class="sr-only">Output list</h2>
-      <ul class="text-sm h-full flex flex-col gap-y-0.5" aria-label="List of outpus" id="outputList" data-cy="outputList">
-        {% for output in output_list %}
-        <li
-          aria-label="Output: {{ output.name }}"
-          class="
-            relative group py-0.5 px-1 hover:bg-slate-50
-            {% if output.status == "fail" %}
-            text-red-800
-            {% elif output.status == "pass" %}
-            text-blue-800
-            {% elif output.status == "review" %}
-            text-fuchsia-900
-            {% endif %}
+  <aside class="overflow-y-scroll bg-white border-r border-zinc-200 py-2">
+    <h2 id="outputListHeader" class="sr-only">Output list</h2>
+    <ul class="text-sm h-full flex flex-col gap-y-0.5" aria-label="List of outputs" id="outputList" data-cy="outputList">
+      {% for output in output_list %}
+      <li
+        aria-label="Output: {{ output.name }}"
+        class="
+          relative group py-0.5 px-1 hover:bg-slate-50
+          {% if output.status == "fail" %}
+          text-red-800
+          {% elif output.status == "pass" %}
+          text-blue-800
+          {% elif output.status == "review" %}
+          text-fuchsia-900
+          {% endif %}
 
-            data-[review-status=true]:bg-green-100/50
-            data-[review-status=false]:bg-red-100/50
-          "
+          data-[review-status=true]:bg-green-100/50
+          data-[review-status=false]:bg-red-100/50
+        "
 
-          data-output-name="{{ output.name }}"
-          data-review-status="none"
-        >
-          <dl class="flex flex-row gap-x-2 items-center" aria-label="Output information">
-            <div class="order-2">
-              <dt class="sr-only">Output name:</dt>
-              <dd>
-                <a
-                  href="#{{ output.url }}"
-                  class="
-                    before:absolute before:inset-0 before:w-full before:h-full
-                  "
-                >
-                  <span class="relative">
-                    {{ output.name }}
-                  </span>
-                </a>
+        data-output-name="{{ output.name }}"
+        data-review-status="none"
+      >
+        <dl class="flex flex-row gap-x-2 items-center" aria-label="Output information">
+          <div class="order-2">
+            <dt class="sr-only">Output name:</dt>
+            <dd>
+              <a
+                href="#{{ output.url }}"
+                class="
+                  before:absolute before:inset-0 before:w-full before:h-full
+                "
+              >
+                <span class="relative">
+                  {{ output.name }}
+                </span>
+              </a>
+            </dd>
+          </div>
+          <div class="order-1">
+            <dt class="sr-only">ACRO status:</dt>
+            <dd>
+              <span class="sr-only">{{ output.status }}</span>
+              {% if output.status == "fail" %}
+              {% icon_file_x class="h-5 w-5 stroke-red-700" %}
+              {% elif output.status == "pass" %}
+              {% icon_file class="h-5 w-5 stroke-blue-700" %}
+              {% elif output.status == "review" %}
+              {% icon_file_unknown class="h-5 w-5 stroke-fuchsia-700" %}
+              {% endif %}
+            </dd>
+          </div>
+          <div class="order-3 ml-auto">
+            <dt class="sr-only">Output type:</dt>
+            <dd>{{ output.type }}</dd>
+          </div>
+          <div class="order-4">
+            <dt class="sr-only">Review status:</dt>
+            <dd>
+              <span class="hidden group-data-[review-status=none]:block">
+                <span class="sr-only">Not yet reviewed</span>
+                <svg class="h-5 w-5"></svg>
+              </span>
+              <span class="hidden group-data-[review-status=true]:block">
+                <span class="sr-only">Approved</span>
+                {% icon_check class="h-5 w-5 text-green-600" %}
+              </span>
+              <span class="hidden group-data-[review-status=false]:block">
+                <span class="sr-only">Rejected</span>
+                {% icon_x_mark class="h-5 w-5 text-red-600" %}
+              </span>
+            </dd>
+          </div>
+        </dl>
+      </li>
+      {% endfor %}
+    </ul>
+  </aside>
+
+  <main class="container overflow-y-scroll">
+    {{ outputs|json_script:"outputData" }}
+
+    <div class="grid gap-y-4">
+      <div class="overflow-hidden bg-white shadow">
+        <div class="p-4">
+          <h1 class="text-xl font-semibold leading-7 text-gray-900" data-sacro-el="outputTitle">
+            Select an output
+          </h1>
+        </div>
+        <div class="border-t border-gray-100">
+          <dl class="divide-y divide-gray-100">
+            <div class="px-4 py-2 grid grid-cols-4 gap-4 hidden" hidden>
+              <dt class="text-sm font-medium text-gray-900">Created at</dt>
+              <dd class="text-sm leading-6 text-gray-700 col-span-3" data-sacro-el="outputCreatedDate"></dd>
+            </div>
+            <div class="px-4 py-2 grid grid-cols-4 gap-4 hidden" hidden>
+              <dt class="text-sm font-medium text-gray-900">Output type</dt>
+              <dd class="text-sm leading-6 text-gray-700 col-span-3" data-sacro-el="outputType"></dd>
+            </div>
+            <div class="px-4 py-2 grid grid-cols-4 gap-4 hidden" hidden>
+              <dt class="text-sm font-medium text-gray-900">ACRO status</dt>
+              <dd class="text-sm leading-6 text-gray-700 col-span-3">
+                <span data-sacro-el="outputDetailsStatus"></span>
+                <span data-sacro-el="outputDetailsSummary"></span>
               </dd>
             </div>
-            <div class="order-1">
-              <dt class="sr-only">ACRO status:</dt>
-              <dd>
-                <span class="sr-only">{{ output.status }}</span>
-                {% if output.status == "fail" %}
-                {% icon_file_x class="h-5 w-5 stroke-red-700" %}
-                {% elif output.status == "pass" %}
-                {% icon_file class="h-5 w-5 stroke-blue-700" %}
-                {% elif output.status == "review" %}
-                {% icon_file_unknown class="h-5 w-5 stroke-fuchsia-700" %}
-                {% endif %}
+            <div class="px-4 py-2 grid grid-cols-4 gap-4 hidden" hidden>
+              <dt class="text-sm font-medium text-gray-900">Comments</dt>
+              <dd class="text-sm leading-6 text-gray-700 col-span-3">
+                <ul data-sacro-el="outputDetailsComments" class="list-disc ml-4">
+                </ul>
               </dd>
             </div>
-            <div class="order-3 ml-auto">
-              <dt class="sr-only">Output type:</dt>
-              <dd>{{ output.type }}</dd>
-            </div>
-            <div class="order-4">
-              <dt class="sr-only">Review status:</dt>
-              <dd>
-                <span class="hidden group-data-[review-status=none]:block">
-                  <span class="sr-only">Not yet reviewed</span>
-                  <svg class="h-5 w-5"></svg>
-                </span>
-                <span class="hidden group-data-[review-status=true]:block">
-                  <span class="sr-only">Approved</span>
-                  {% icon_check class="h-5 w-5 text-green-600" %}
-                </span>
-                <span class="hidden group-data-[review-status=false]:block">
-                  <span class="sr-only">Rejected</span>
-                  {% icon_x_mark class="h-5 w-5 text-red-600" %}
-                </span>
+            <div class="px-4 py-2 grid grid-cols-4 gap-4 hidden" hidden>
+              <dt class="text-sm font-medium text-gray-900">Review</dt>
+              <dd class="text-sm leading-6 text-gray-700 col-span-3">
+                <span data-sacro-el="outputDetailsReviewForm" id="outputMetadata"></span>
               </dd>
             </div>
           </dl>
-        </li>
-        {% endfor %}
-      </ul>
-    </aside>
-
-    <main class="container overflow-y-scroll">
-      {{ outputs|json_script:"outputData" }}
-
-      <div class="grid gap-y-4">
-        <div class="overflow-hidden bg-white shadow">
-          <div class="p-4">
-            <h1 class="text-xl font-semibold leading-7 text-gray-900" data-sacro-el="outputTitle">
-              Select an output
-            </h1>
-          </div>
-          <div class="border-t border-gray-100">
-            <dl class="divide-y divide-gray-100">
-              <div class="px-4 py-2 grid grid-cols-4 gap-4 hidden" hidden>
-                <dt class="text-sm font-medium text-gray-900">Created at</dt>
-                <dd class="text-sm leading-6 text-gray-700 col-span-3" data-sacro-el="outputCreatedDate"></dd>
-              </div>
-              <div class="px-4 py-2 grid grid-cols-4 gap-4 hidden" hidden>
-                <dt class="text-sm font-medium text-gray-900">Output type</dt>
-                <dd class="text-sm leading-6 text-gray-700 col-span-3" data-sacro-el="outputType"></dd>
-              </div>
-              <div class="px-4 py-2 grid grid-cols-4 gap-4 hidden" hidden>
-                <dt class="text-sm font-medium text-gray-900">ACRO status</dt>
-                <dd class="text-sm leading-6 text-gray-700 col-span-3">
-                  <span data-sacro-el="outputDetailsStatus"></span>
-                  <span data-sacro-el="outputDetailsSummary"></span>
-                </dd>
-              </div>
-              <div class="px-4 py-2 grid grid-cols-4 gap-4 hidden" hidden>
-                <dt class="text-sm font-medium text-gray-900">Comments</dt>
-                <dd class="text-sm leading-6 text-gray-700 col-span-3">
-                  <ul data-sacro-el="outputDetailsComments" class="list-disc ml-4">
-                  </ul>
-                </dd>
-              </div>
-              <div class="px-4 py-2 grid grid-cols-4 gap-4 hidden" hidden>
-                <dt class="text-sm font-medium text-gray-900">Review</dt>
-                <dd class="text-sm leading-6 text-gray-700 col-span-3">
-                  <span data-sacro-el="outputDetailsReviewForm" id="outputMetadata"></span>
-                </dd>
-              </div>
-            </dl>
-          </div>
         </div>
-
-        {% #card title="Select an output" container=True container_id="fileContent" class="hidden" %}
-        {% /card %}
       </div>
 
-    </main>
+      {% #card title="Select an output" container=True container_id="fileContent" class="hidden" %}
+      {% /card %}
+    </div>
+  </main>
 
-    {% #modal id="submitModal" title="Release and download" subtitle='<span class="count"></span> files are ready to be released' %}
-      <p>Record your assessment of the whole release request below.</p>
-      <p>
-        For example, if there are disclosivity concerns that span multiple
-        outputs, or if significant changes are needed to the whole study before
-        it can be released.
-      </p>
+  {% #modal id="submitModal" title="Release and download" subtitle='<span class="count"></span> files are ready to be released' %}
+    <p>Record your assessment of the whole release request below.</p>
+    <p>
+      For example, if there are disclosivity concerns that span multiple
+      outputs, or if significant changes are needed to the whole study before
+      it can be released.
+    </p>
 
-      <div class="">
-        <textarea name="comment"
-          class="
-            my-1 block w-full rounded-md border-slate-300 text-slate-900 shadow-sm resize-none
-            sm:text-sm
-            focus:border-oxford-500 focus:ring-oxford-500
-            invalid:border-bn-ribbon-600 invalid:ring-bn-ribbon-600 invalid:ring-1
-          "
-          id="id_comment"
-          type="text"
-        ></textarea>
-      </div>
+    <div class="">
+      <textarea name="comment"
+        class="
+          my-1 block w-full rounded-md border-slate-300 text-slate-900 shadow-sm resize-none
+          sm:text-sm
+          focus:border-oxford-500 focus:ring-oxford-500
+          invalid:border-bn-ribbon-600 invalid:ring-bn-ribbon-600 invalid:ring-1
+        "
+        id="id_comment"
+        type="text"
+      ></textarea>
+    </div>
 
-      <p>Click the button below to download a zip file of the files you have approved.</p>
+    <p>Click the button below to download a zip file of the files you have approved.</p>
 
-      <form action="{{ review_url }}" method="post" id="approveForm">
-        {% csrf_token %}
-        {% #button type="submit" disabled=True %}
-          Submit
-        {% /button %}
-      </form>
+    <form action="{{ review_url }}" method="post" id="approveForm">
+      {% csrf_token %}
+      {% #button type="submit" disabled=True %}
+        Submit
+      {% /button %}
+    </form>
 
-    {% /modal %}
-
-  </body>
-</html>
+  {% /modal %}
+</body>
+{% endblock content %}


### PR DESCRIPTION
We're going to be adding another template for the summary page but want to make this change now so as to avoid holding up concurrent work on the main viewer page.

I've pulled the header out into a component because we'll want to maintain that for the second page but not have the Release and download button so optional children was the ideal solution.

Ref: #149 