### PR TITLE
Include cypress tests in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,6 +73,18 @@ jobs:
         with:
           start: just run
           wait-on: "http://localhost:8000/"
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: cypress-screenshots
+          path: cypress/screenshots
+          if-no-files-found: ignore
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: cypress-videos
+          path: cypress/videos
+          if-no-files-found: ignore
 
   build-windows:
     needs: [check, test-windows]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,6 +75,7 @@ jobs:
           wait-on: "http://localhost:8000/"
 
   build-windows:
+    needs: [check, test-windows]
     permissions:
       contents: write
     runs-on: windows-2022

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,31 @@ jobs:
       - name: Build app
         run: just sacro-app/build
 
+  test-windows:
+    runs-on: windows-2022
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: "opensafely-core/setup-action@v1"
+        with:
+          python-version: "3.11"
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.node-version'
+          cache: "npm"
+          cache-dependency-path: |
+            **/package-lock.json
+            sacro-app/package-lock.json
+      # our just setup doesn't make just available on the path
+      - uses: extractions/setup-just@69d82fb0233557aec017ef13706851d0694e0f1d
+      - name: Run tests
+        run: just test
+      - name: Cypress run
+        uses: cypress-io/github-action@d69252d52b9a31bad4f418f05ba2bc83687a02eb #v5.8.3
+        with:
+          start: just run
+          wait-on: "http://localhost:8000/"
+
   build-windows:
     permissions:
       contents: write
@@ -68,8 +93,6 @@ jobs:
             sacro-app/package-lock.json
       # our just setup doesn't make just available on the path
       - uses: extractions/setup-just@69d82fb0233557aec017ef13706851d0694e0f1d
-      - name: Run tests
-        run: just test
       - name: Build binary
         run: just build
       - name: Build app


### PR DESCRIPTION
An example of a test failure
https://github.com/opensafely-core/sacro/actions/runs/5487476633

![Screenshot from 2023-07-07 15-36-19](https://github.com/opensafely-core/sacro/assets/3889554/e3fa6e1b-08dc-4518-8d6d-57d2cc870b3e)
