### PR TITLE
Add a review success page

### DIFF
--- a/assets/src/scripts/_form-setup.js
+++ b/assets/src/scripts/_form-setup.js
@@ -57,9 +57,6 @@ const formSetup = () => {
       submit.setAttribute("title", "");
     }
   });
-
-  // FIXME: what to do on submit?
-  submit.addEventListener("click", () => {});
 };
 
 export default formSetup;

--- a/assets/src/scripts/review.js
+++ b/assets/src/scripts/review.js
@@ -1,0 +1,1 @@
+import "../styles/review.css";

--- a/assets/src/styles/index.css
+++ b/assets/src/styles/index.css
@@ -14,6 +14,16 @@ body > main {
   padding-block: 0.5rem;
 }
 
+.header {
+  align-items: center;
+  background-color: var(--color-white);
+  border-bottom: 1px solid var(--color-zinc-200);
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  padding: 1rem;
+}
+
 li.selected {
   background-color: lightgrey;
 }

--- a/assets/src/styles/index.css
+++ b/assets/src/styles/index.css
@@ -14,16 +14,6 @@ body > main {
   padding-block: 0.5rem;
 }
 
-.header {
-  align-items: center;
-  background-color: var(--color-white);
-  border-bottom: 1px solid var(--color-zinc-200);
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  padding: 1rem;
-}
-
 li.selected {
   background-color: lightgrey;
 }

--- a/assets/src/styles/review.css
+++ b/assets/src/styles/review.css
@@ -1,0 +1,4 @@
+body {
+  grid-template-rows: max-content 1fr;
+  grid-template-columns: 1fr minmax(min-content, 2fr) 1fr;
+}

--- a/assets/src/styles/review.css
+++ b/assets/src/styles/review.css
@@ -1,4 +1,5 @@
 body {
-  grid-template-rows: max-content 1fr;
-  grid-template-columns: 1fr minmax(min-content, 2fr) 1fr;
+  display: flex;
+  flex-direction: column;
+  background-color: var(--color-zinc-100);
 }

--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -54,3 +54,56 @@ describe("Approve all files, view summary page, and download approved outputs", 
       });
   });
 });
+
+describe("Approve all files, view summary page, and download summary", () => {
+  it("passes", () => {
+    cy.visit("http://localhost:8000");
+
+    // comment on and approve each output
+    cy.get("[data-sacro-el='outputList'] li").each(($el) => {
+      cy.wrap($el).click();
+
+      cy.get("[data-sacro-el='outputDetailsTextareaComments']").type(
+        "This is a comment"
+      );
+      cy.get("[data-sacro-el='outputDetailsBtnApprove']").click();
+    });
+
+    // open the modal, comment, and submit the form
+    cy.get("button#openModalBtn").click();
+    cy.get("[data-sacro-el='submissionComment']").type(
+      "Everything has been approved"
+    );
+    cy.get("#approveForm").submit();
+
+    cy.url().should("eq", "http://localhost:8000/review/current/");
+    //
+    // prepare for form submission that returns back a file
+    // https://on.cypress.io/intercept
+    cy.intercept(
+      {
+        pathname: "/review/current/summary/",
+        method: "POST",
+      },
+      (req) => {
+        // instead of redirecting to the zip file
+        // and having the browser deal with it,
+        // we download the file ourselves
+        // but we cannot use Cypress commands inside the callback
+        // so we will download it later using the captured URL
+        req.redirect("/");
+      }
+    ).as("records");
+
+    cy.get("[data-sacro-el='downloadSummaryForm']").submit();
+
+    cy.wait("@records")
+      .its("request")
+      .then((req) => {
+        cy.request(req).then(({ headers }) => {
+          const { "content-type": contentType } = headers;
+          expect(contentType).to.be.oneOf(["text/plain"]);
+        });
+      });
+  });
+});

--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -35,13 +35,13 @@ describe("Approve all files, view summary page, and download approved outputs", 
         // we download the file ourselves
         // but we cannot use Cypress commands inside the callback
         // so we will download it later using the captured URL
-        req.redirect("/");
+        req.redirect("/review/current");
       }
-    ).as("records");
+    ).as("approvedOutputs");
 
     cy.get("[data-sacro-el='downloadOutputsForm']").submit();
 
-    cy.wait("@records")
+    cy.wait("@approvedOutputs")
       .its("request")
       .then((req) => {
         cy.request(req).then(({ headers }) => {
@@ -52,34 +52,7 @@ describe("Approve all files, view summary page, and download approved outputs", 
           ]);
         });
       });
-  });
-});
 
-describe("Approve all files, view summary page, and download summary", () => {
-  it("passes", () => {
-    cy.visit("http://localhost:8000");
-
-    // comment on and approve each output
-    cy.get("[data-sacro-el='outputList'] li").each(($el) => {
-      cy.wrap($el).click();
-
-      cy.get("[data-sacro-el='outputDetailsTextareaComments']").type(
-        "This is a comment"
-      );
-      cy.get("[data-sacro-el='outputDetailsBtnApprove']").click();
-    });
-
-    // open the modal, comment, and submit the form
-    cy.get("button#openModalBtn").click();
-    cy.get("[data-sacro-el='submissionComment']").type(
-      "Everything has been approved"
-    );
-    cy.get("#approveForm").submit();
-
-    cy.url().should("eq", "http://localhost:8000/review/current/");
-    //
-    // prepare for form submission that returns back a file
-    // https://on.cypress.io/intercept
     cy.intercept(
       {
         pathname: "/review/current/summary/",
@@ -93,16 +66,16 @@ describe("Approve all files, view summary page, and download summary", () => {
         // so we will download it later using the captured URL
         req.redirect("/");
       }
-    ).as("records");
+    ).as("summary");
 
     cy.get("[data-sacro-el='downloadSummaryForm']").submit();
 
-    cy.wait("@records")
+    cy.wait("@summary")
       .its("request")
       .then((req) => {
         cy.request(req).then(({ headers }) => {
           const { "content-type": contentType } = headers;
-          expect(contentType).to.be.oneOf(["text/plain"]);
+          expect(contentType).to.equal("text/plain");
         });
       });
   });

--- a/sacro/templates/components/button.html
+++ b/sacro/templates/components/button.html
@@ -42,6 +42,10 @@
         bg-bn-ribbon-600 text-white
         hover:bg-bn-ribbon-700
         focus:ring-bn-ribbon-500 focus:ring-offset-white
+      {% elif variant == "danger-outline" %}
+        bg-transparent border border-red-700 text-red-700
+        hover:bg-red-100
+        focus:bg-red-100 focus:ring-red-500 focus:ring-offset-white
       {% elif variant == "warning" %}
         bg-bn-flamenco-600 text-white
         hover:bg-bn-flamenco-700

--- a/sacro/templates/components/header.html
+++ b/sacro/templates/components/header.html
@@ -1,6 +1,13 @@
 {% load static %}
 
-<header class="header">
+<header
+  class="
+    bg-white
+    border border-b-zinc-200
+    flex justify-between items-center
+    p-4
+  "
+>
   <div class="flex gap-x-4 items-center">
     <img
       alt="SACRO logo"

--- a/sacro/templates/components/modal.html
+++ b/sacro/templates/components/modal.html
@@ -23,7 +23,6 @@
     <div class="
       px-4 py-3 md:px-6 md:py-5
       border-t border-slate-200
-      flex flex-col gap-3
     ">
       {{ children }}
     </div>

--- a/sacro/templates/index.html
+++ b/sacro/templates/index.html
@@ -139,7 +139,7 @@
   </main>
 
   {% #modal id="submitModal" title="Release and download" subtitle='<span class="count"></span> files are ready to be released' %}
-    <form action="{{ submission_url }}" method="post" id="approveForm" class="flex flex-col gap-3">
+    <form action="{{ create_url }}" method="post" id="approveForm" class="flex flex-col gap-3">
       {% csrf_token %}
 
       <p>Record your assessment of the whole release request below.</p>

--- a/sacro/templates/index.html
+++ b/sacro/templates/index.html
@@ -62,7 +62,7 @@
               {% endif %}
             </dd>
           </div>
-          <div class="order-3 ml-auto">
+          <div class="order-3 ml-auto text-right">
             <dt class="sr-only">Output type:</dt>
             <dd>{{ output.properties.method|default_if_none:"" }} {{ output.type }}</dd>
           </div>

--- a/sacro/templates/index.html
+++ b/sacro/templates/index.html
@@ -8,12 +8,12 @@
 {% endblock %}
 
 {% block content %}
-  <body class="grid h-screen overflow-hidden bg-zinc-100">
-    {% #header %}
-      {% #button disabled=True id="openModalBtn" type="submit" %}
-        Release and download
-      {% /button %}
-    {% /header %}
+<body class="grid h-screen overflow-hidden bg-zinc-100">
+  {% #header %}
+    {% #button disabled=True id="openModalBtn" type="submit" %}
+      Release and download
+    {% /button %}
+  {% /header %}
 
   <aside class="overflow-y-auto bg-white border-r border-zinc-200 py-2">
     <h2 id="outputListHeader" class="sr-only">Output list</h2>
@@ -139,14 +139,16 @@
   </main>
 
   {% #modal id="submitModal" title="Release and download" subtitle='<span class="count"></span> files are ready to be released' %}
-    <p>Record your assessment of the whole release request below.</p>
-    <p>
-      For example, if there are disclosivity concerns that span multiple
-      outputs, or if significant changes are needed to the whole study before
-      it can be released.
-    </p>
+    <form action="{{ submission_url }}" method="post" id="approveForm" class="flex flex-col gap-3">
+      {% csrf_token %}
 
-    <div class="">
+      <p>Record your assessment of the whole release request below.</p>
+      <p>
+        For example, if there are disclosivity concerns that span multiple
+        outputs, or if significant changes are needed to the whole study before
+        it can be released.
+      </p>
+
       <textarea name="comment"
         class="
           my-1 block w-full rounded-md border-slate-300 text-slate-900 shadow-sm resize-none
@@ -158,15 +160,14 @@
         data-sacro-el="submissionComment"
         type="text"
       ></textarea>
-    </div>
 
-    <p>Click the button below to download a zip file of the files you have approved.</p>
+      <p>Click the button below to download a zip file of the files you have approved.</p>
 
-    <form action="{{ review_url }}" method="post" id="approveForm">
-      {% csrf_token %}
-      {% #button type="submit" disabled=True %}
-        Submit
-      {% /button %}
+      <div>
+        {% #button type="submit" disabled=True %}
+          Submit
+        {% /button %}
+      </div>
     </form>
 
   {% /modal %}

--- a/sacro/templates/review.html
+++ b/sacro/templates/review.html
@@ -27,6 +27,14 @@
           Download approved outputs
         {% /button %}
       </form>
+
+      <form action="{{ summary_url }}" method="POST" data-sacro-el="downloadSummaryForm">
+        {% csrf_token %}
+
+        {% #button type="submit" variant="success" %}
+          Download review summary
+        {% /button %}
+      </form>
     </div>
 
   </main>

--- a/sacro/templates/review.html
+++ b/sacro/templates/review.html
@@ -10,33 +10,46 @@
 <body class="grid">
   {% #header %}{% /header %}
 
-  <main class="col-start-2 flex flex-col gap-3 pt-5">
-    <h1 class="text-xl font-semibold leading-7 text-gray-900">Review complete</h1>
+  <main class="container w-full mx-auto">
+    <div class="flex flex-col gap-3 pt-5">
+      <div class="mb-4">
+        <h1 class="text-xl font-bold leading-6 text-gray-900">Review complete</h3>
+        <dl class="mt-5 grid grid-cols-1 gap-5 sm:grid-cols-3">
+          <div class="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
+            <dt class="truncate text-sm font-medium text-zinc-700">Outputs reviewed</dt>
+            <dd class="mt-1 text-3xl font-semibold tracking-tight text-zinc-800">{{ counts.total }}</dd>
+          </div>
+          <div class="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
+            <dt class="truncate text-sm font-medium text-green-900">Outputs approved</dt>
+            <dd class="mt-1 text-3xl font-semibold tracking-tight text-green-700">{{ counts.approved }}</dd>
+          </div>
+          <div class="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
+            <dt class="truncate text-sm font-medium text-red-900">Outputs rejected</dt>
+            <dd class="mt-1 text-3xl font-semibold tracking-tight text-red-700">{{ counts.rejected }}</dd>
+          </div>
+        </dl>
+      </div>
 
-    <div>
-      <p>Outputs reviewed: {{ counts.total }}</p>
-      <p>Outputs approved: {{ counts.approved }}</p>
-      <p>Outputs rejected: {{ counts.rejected }}</p>
+      <div class="flex flex-col items-start gap-3">
+        <form action="{{ approved_outputs_url }}" method="POST" data-sacro-el="downloadOutputsForm">
+          {% csrf_token %}
+
+          {% #button type="submit" variant="success" %}
+            Download approved outputs
+          {% /button %}
+        </form>
+
+        <form action="{{ summary_url }}" method="POST" data-sacro-el="downloadSummaryForm">
+          {% csrf_token %}
+
+          {% #button type="submit" variant="primary" %}
+            Download review summary
+          {% /button %}
+        </form>
+
+        <p>Once your downloads have completed, you can close this application.</p>
+      </div>
     </div>
-
-    <div class="flex items-center gap-3">
-      <form action="{{ approved_outputs_url }}" method="POST" data-sacro-el="downloadOutputsForm">
-        {% csrf_token %}
-
-        {% #button type="submit" variant="success" %}
-          Download approved outputs
-        {% /button %}
-      </form>
-
-      <form action="{{ summary_url }}" method="POST" data-sacro-el="downloadSummaryForm">
-        {% csrf_token %}
-
-        {% #button type="submit" variant="success" %}
-          Download review summary
-        {% /button %}
-      </form>
-    </div>
-
   </main>
 </body>
 {% endblock content %}

--- a/sacro/templates/review.html
+++ b/sacro/templates/review.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+
+{% load django_vite %}
+
+{% block extra_head %}
+{% vite_asset "assets/src/scripts/review.js" %}
+{% endblock %}
+
+{% block content %}
+<body class="grid">
+  {% #header %}{% /header %}
+
+  <main class="col-start-2 flex flex-col gap-3 pt-5">
+    <h1 class="text-xl font-semibold leading-7 text-gray-900">Review complete</h1>
+
+    <div>
+      <p>Outputs reviewed: {{ counts.total }}</p>
+      <p>Outputs approved: {{ counts.approved }}</p>
+      <p>Outputs rejected: {{ counts.rejected }}</p>
+    </div>
+
+    <div class="flex items-center gap-3">
+      <form action="{{ approved_outputs_url }}" method="POST" data-sacro-el="downloadOutputsForm">
+        {% csrf_token %}
+
+        {% #button type="submit" variant="success" %}
+          Download approved outputs
+        {% /button %}
+      </form>
+    </div>
+
+  </main>
+</body>
+{% endblock content %}

--- a/sacro/templates/summary.txt
+++ b/sacro/templates/summary.txt
@@ -1,0 +1,11 @@
+# Review summary
+{{ review.comment }}
+
+{% for name, meta in review.decisions.items %}
+## {{ name }}
+ACRO status: {{ meta.acro_status }}
+Reviewer status: {% if meta.state %}approved{% else %}rejected{% endif %}
+
+{% if meta.comment %}{{ meta.comment}}{% endif %}
+
+{% endfor %}

--- a/sacro/urls.py
+++ b/sacro/urls.py
@@ -9,7 +9,7 @@ from sacro import views
 urlpatterns = [
     path("", views.index, name="index"),
     path("contents/", views.contents, name="contents"),
-    path("review/", views.review, name="review"),
+    path("review/", views.review_create, name="review-create"),
 ]
 
 if settings.DEBUG and importlib.util.find_spec(

--- a/sacro/urls.py
+++ b/sacro/urls.py
@@ -10,6 +10,12 @@ urlpatterns = [
     path("", views.index, name="index"),
     path("contents/", views.contents, name="contents"),
     path("review/", views.review_create, name="review-create"),
+    path("review/<str:pk>/", views.review_detail, name="review-detail"),
+    path(
+        "review/<str:pk>/approved-outputs/",
+        views.approved_outputs,
+        name="approved-outputs",
+    ),
 ]
 
 if settings.DEBUG and importlib.util.find_spec(

--- a/sacro/urls.py
+++ b/sacro/urls.py
@@ -16,6 +16,7 @@ urlpatterns = [
         views.approved_outputs,
         name="approved-outputs",
     ),
+    path("review/<str:pk>/summary/", views.summary, name="summary"),
 ]
 
 if settings.DEBUG and importlib.util.find_spec(

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -27,7 +27,7 @@ def test_index(test_outputs):
     response = views.index(request)
     assert response.context_data["outputs"] == dict(test_outputs)
     assert (
-        response.context_data["review_url"]
+        response.context_data["create_url"]
         == f"/review/?{urlencode({'path': test_outputs.path})}"
     )
 
@@ -82,28 +82,51 @@ def test_contents_not_in_outputs(test_outputs):
         views.contents(request)
 
 
-def get_review_url_request(outputs_metadata, review_data):
-    # we currently use a query param to pass the path, but this is a POST
-    # so we use a get request to build the query string url, and then POST to that
-    rq = RequestFactory()
-    url = rq.get("/review", data={"path": str(outputs_metadata.path)}).get_full_path()
-    data = {}
-    if review_data:
-        data["review"] = json.dumps(review_data)
-    return rq.post(url, data=data)
-
-
 @pytest.fixture
 def review_data(test_outputs):
     return {k: {"state": False, "comments": "comment"} for k in test_outputs.keys()}
 
 
-def test_review_success_all_files(test_outputs, review_data):
+@pytest.fixture
+def review_summary(review_data, test_outputs):
+    return {
+        "comment": "test comment",
+        "decisions": review_data,
+        "path": test_outputs.path,
+    }
+
+
+def test_approved_outputs_missing_metadata(tmp_path, monkeypatch):
+    path = tmp_path / "results.json"
+    path.write_text(json.dumps({"test": {"output": ["does-not-exist"]}}))
+
+    review_data = {"decisions": {"test": {"state": True}}, "path": path}
+    monkeypatch.setattr(views, "REVIEWS", {"current": review_data})
+
+    request = RequestFactory().post("/")
+
+    response = views.approved_outputs(request, pk="current")
+
+    zf = io.BytesIO(response.getvalue())
+    with zipfile.ZipFile(zf, "r") as zip_obj:
+        assert zip_obj.testzip() is None
+        assert zip_obj.namelist() == ["missing-files.txt"]
+        contents = zip_obj.open("missing-files.txt").read().decode("utf8")
+        assert "were not found" in contents
+        assert "does-not-exist" in contents
+
+
+def test_approved_outputs_success_all_files(test_outputs, review_summary):
     # approve all files
-    for k, v in review_data.items():
+    for k, v in review_summary["decisions"].items():
         v["state"] = True
-    request = get_review_url_request(test_outputs, review_data)
-    response = views.review(request)
+
+    views.REVIEWS["current"] = review_summary
+
+    path = urlencode({"path": test_outputs.path})
+    request = RequestFactory().post(f"/?{path}")
+
+    response = views.approved_outputs(request, pk="current")
 
     expected_namelist = []
 
@@ -119,40 +142,75 @@ def test_review_success_all_files(test_outputs, review_data):
         assert zip_obj.namelist() == expected_namelist
 
 
-def test_review_success_no_files(test_outputs, review_data):
-    request = get_review_url_request(test_outputs, None)
-    response = views.review(request)
-    assert response.status_code == 400
-
-
-def test_review_success_unrecognized_files(test_outputs):
-    bad_data = {"output-does-not-exist": {"state": True}}
-    request = get_review_url_request(test_outputs, bad_data)
-    response = views.review(request)
-    assert response.status_code == 400
-
-
-def test_review_missing_metadata(tmp_path):
-    path = tmp_path / "results.json"
-    path.write_text(json.dumps({"test": {"output": ["does-not-exist"]}}))
-    review_data = {"test": {"state": True}}
-    url = RequestFactory().get("/review", data={"path": str(path)}).get_full_path()
-    request = RequestFactory().post(url, data={"review": json.dumps(review_data)})
-    response = views.review(request)
-    zf = io.BytesIO(response.getvalue())
-    with zipfile.ZipFile(zf, "r") as zip_obj:
-        assert zip_obj.testzip() is None
-        assert zip_obj.namelist() == ["missing-files.txt"]
-        contents = zip_obj.open("missing-files.txt").read().decode("utf8")
-        assert "were not found" in contents
-        assert "does-not-exist" in contents
-
-
-def test_review_success_logs_audit_trail(test_outputs, review_data, mocker):
+def test_approved_outputs_success_logs_audit_trail(
+    test_outputs, review_summary, mocker, monkeypatch
+):
+    monkeypatch.setattr(views, "REVIEWS", {"current": review_summary})
     mocked_local_audit = mocker.patch("sacro.views.local_audit")
-    request = get_review_url_request(test_outputs, review_data)
 
-    response = views.review(request)
+    path = urlencode({"path": test_outputs.path})
+    request = RequestFactory().post(f"/?{path}")
+
+    response = views.approved_outputs(request, pk="current")
 
     assert response.status_code == 200
     mocked_local_audit.log_release.assert_called_once()
+
+
+def test_approved_outputs_unknown_review(review_summary, monkeypatch):
+    monkeypatch.setattr(views, "REVIEWS", {"current": review_summary})
+
+    request = RequestFactory().post("/")
+
+    with pytest.raises(Http404):
+        views.approved_outputs(request, pk="test")
+
+
+def test_review_create_no_comment(test_outputs, review_data):
+    path = urlencode({"path": test_outputs.path})
+    request = RequestFactory().post(f"/?{path}", data={"review": review_data})
+
+    response = views.review_create(request)
+
+    assert response.status_code == 400
+    assert b"no comment data submitted" in response.content
+
+
+def test_review_create_no_review_data(test_outputs):
+    path = urlencode({"path": test_outputs.path})
+    request = RequestFactory().post(f"/?{path}", data={"comment": "test"})
+
+    response = views.review_create(request)
+
+    assert response.status_code == 400
+    assert b"no review data submitted" in response.content
+
+
+def test_review_create_success(test_outputs, review_data, monkeypatch):
+    path = urlencode({"path": test_outputs.path})
+    request = RequestFactory().post(
+        f"/?{path}", data={"comment": "test", "review": json.dumps(review_data)}
+    )
+
+    response = views.review_create(request)
+
+    assert response.status_code == 200
+    assert views.REVIEWS["current"] == {
+        "comment": "test",
+        "decisions": review_data,
+        "path": test_outputs.path,
+    }
+
+
+def test_review_create_unrecognized_files(test_outputs):
+    bad_data = {"output-does-not-exist": {"state": True}}
+    path = urlencode({"path": test_outputs.path})
+    request = RequestFactory().post(
+        f"/?{path}",
+        data={"comment": "test", "review": json.dumps(bad_data)},
+    )
+
+    response = views.review_create(request)
+
+    assert response.status_code == 400, response.content
+    assert b"invalid output names" in response.content

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -236,3 +236,27 @@ def test_review_detail_unknown_review(review_summary, monkeypatch):
 
     with pytest.raises(Http404):
         views.review_detail(request, pk="test")
+
+
+def test_summary_success(review_summary, monkeypatch):
+    monkeypatch.setattr(views, "REVIEWS", {"current": review_summary})
+
+    request = RequestFactory().post("/")
+
+    response = views.summary(request, pk="current")
+
+    assert response.status_code == 200
+
+    content = response.getvalue().decode("utf-8")
+    assert review_summary["comment"] in content
+    for name in review_summary["decisions"].keys():
+        assert name in content
+
+
+def test_summary_unknown_review(review_summary, monkeypatch):
+    monkeypatch.setattr(views, "REVIEWS", {"current": review_summary})
+
+    request = RequestFactory().post("/")
+
+    with pytest.raises(Http404):
+        views.summary(request, pk="test")

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,7 +5,11 @@ export default defineConfig({
   build: {
     manifest: true,
     rollupOptions: {
-      input: ["./assets/src/scripts/base.js", "./assets/src/scripts/index.js"],
+      input: [
+        "./assets/src/scripts/base.js",
+        "./assets/src/scripts/index.js",
+        "./assets/src/scripts/review.js",
+      ],
     },
     outDir: "assets/dist",
     emptyOutDir: true,


### PR DESCRIPTION
This fleshes out the submission of a review to add a final page where a user can download the approved outputs and a summary of the review for use elsewhere.

**Review complete page:**

<img width="758" alt="Screenshot 2023-07-10 111128" src="https://github.com/opensafely-core/sacro/assets/24863179/0c2b75a8-919d-48e4-9830-640bf562cf2e">

---

**Summary document:**
![](https://p198.p4.n0.cdn.getcloudapp.com/items/E0uLjd8O/c1112986-46fc-4f48-9ec2-4cb7fb2b75b4.jpg?v=d86f23ee44d35a3020be2c4e206c8636)

Fix: #149 
Fix: #139 