### PR TITLE
Failing cells are highlighted

### DIFF
--- a/assets/src/scripts/_table-builder.js
+++ b/assets/src/scripts/_table-builder.js
@@ -4,6 +4,27 @@ import { html } from "./_utils";
 const indexOfAll = (arr, val) =>
   arr.reduce((acc, el, i) => (el !== val ? [...acc, i] : acc), []);
 
+function highlightFailingCells(columnName, columnOutcome, headings) {
+  const rows = indexOfAll(Object.values(columnOutcome), "ok");
+  const column = headings.findIndex((val) => val === columnName);
+
+  const colData = rows.map((row) => {
+    const tableBody = document.getElementById("csvBody");
+    const tableRow = tableBody.children[row];
+    const tableCell = tableRow.children[column];
+
+    tableCell.setAttribute("title", Object.values(columnOutcome)[row]);
+    tableCell.classList.add(
+      "bg-red-50",
+      "!border",
+      "!border-red-600",
+      "text-red-900"
+    );
+    return tableCell;
+  });
+  return colData;
+}
+
 function tableBuilder({ csvString, el, outcome }) {
   const csvToJson = Papa.parse(csvString).data;
 
@@ -35,31 +56,9 @@ function tableBuilder({ csvString, el, outcome }) {
 
   el.innerHTML = table; // eslint-disable-line no-param-reassign
 
-  Object.keys(outcome).map((key) => {
-    const rows = indexOfAll(Object.values(outcome[key]), "ok");
-    const column = csvToJson[0].findIndex((val) => val === key);
-
-    const colData = rows.map((row) => {
-      const tableBody = document.getElementById("csvBody");
-      const tableRow = tableBody.children[row];
-      const tableCell = tableRow.children[column];
-
-      tableCell.innerHTML = Object.values(outcome[key])
-        [row].split("; ")
-        .filter((i) => i !== "")
-        .map((i) => html`<span class="block">${i}</span>`)
-        .join("");
-
-      return tableCell.classList.add(
-        "bg-red-50",
-        "!border",
-        "!border-red-600",
-        "text-red-900"
-      );
-    });
-
-    return colData;
-  });
+  Object.keys(outcome).map((columnName) =>
+    highlightFailingCells(columnName, outcome[columnName], csvToJson[0])
+  );
 }
 
 export default tableBuilder;

--- a/assets/src/scripts/_table-builder.js
+++ b/assets/src/scripts/_table-builder.js
@@ -4,6 +4,13 @@ import { html } from "./_utils";
 const indexOfAll = (arr, val) =>
   arr.reduce((acc, el, i) => (el !== val ? [...acc, i] : acc), []);
 
+/**
+ *
+ * @param {string} columnName
+ * @param {object} columnOutcome
+ * @param {string[]} headings
+ * @returns
+ */
 function highlightFailingCells(columnName, columnOutcome, headings) {
   const rows = indexOfAll(Object.values(columnOutcome), "ok");
   const column = headings.findIndex((val) => val === columnName);
@@ -13,13 +20,32 @@ function highlightFailingCells(columnName, columnOutcome, headings) {
     const tableRow = tableBody.children[row];
     const tableCell = tableRow.children[column];
 
-    tableCell.setAttribute("title", Object.values(columnOutcome)[row]);
     tableCell.classList.add(
       "bg-red-50",
       "!border",
       "!border-red-600",
-      "text-red-900"
+      "text-red-900",
+      "relative",
+      "group",
+      "cursor-pointer"
     );
+
+    const tooltipContent = Object.values(columnOutcome)
+      [row].split("; ")
+      .filter((i) => i !== "")
+      .map((i) => html`<span class="block">${i}</span>`)
+      .join("");
+
+    const tooltipTemplateEl = document.getElementById(`tooltip`);
+
+    const cellTooltip =
+      tooltipTemplateEl?.content?.firstElementChild.cloneNode(true);
+
+    cellTooltip.classList.add("flex", "-bottom-2");
+    cellTooltip.querySelector(`[data-sacro-el="tooltip-content"]`).innerHTML =
+      tooltipContent;
+    tableCell.appendChild(cellTooltip);
+
     return tableCell;
   });
   return colData;

--- a/sacro/templates/components.yaml
+++ b/sacro/templates/components.yaml
@@ -3,6 +3,7 @@ components:
   card: "components/card.html"
   header: "components/header.html"
   modal: "components/modal.html"
+  tooltip: "components/tooltip.html"
 
   icon_breadcrumb_arrow: "icons/breadcrumb-arrow.svg"
   icon_check: "icons/check.svg"

--- a/sacro/templates/components/tooltip.html
+++ b/sacro/templates/components/tooltip.html
@@ -1,0 +1,11 @@
+<span class="opacity-0 scale-0 z-40 group-hover:opacity-100 group-hover:scale-100 transition-scale-opacity absolute bg-transparent pb-3 translate-y-full left-1/2 -translate-x-1/2 {{ position }}">
+  <span class="
+      {{ class }}
+      text-sm text-semibold w-full min-w-fit whitespace-nowrap bg-red-200 text-red-900 py-2 px-3 rounded shadow-xl text-left relative
+      before:block before:absolute before:-top-1 before:h-3 before:w-3 before:bg-red-200 before:left-1/2 before:-translate-x-1/2 before:rotate-45 before:z-0
+      after:block after:absolute after:-top-3 after:h-full after:w-full after:bg-transparent after:left-1/2 after:-translate-x-1/2 after:z-0
+    "
+  >
+    <span class="relative z-10" data-sacro-el="tooltip-content">{{ content }}</span>
+  </span>
+</span>

--- a/sacro/templates/index.html
+++ b/sacro/templates/index.html
@@ -138,6 +138,10 @@
     </div>
   </main>
 
+  <template id="tooltip">
+    {% tooltip %}
+  </template>
+
   {% #modal id="submitModal" title="Release and download" subtitle='<span class="count"></span> files are ready to be released' %}
     <form action="{{ create_url }}" method="post" id="approveForm" class="flex flex-col gap-3">
       {% csrf_token %}


### PR DESCRIPTION
Previously failing cells were suppressed rather than highlighted, but a change to ACRO means that we should show the values instead. Details of the failure are shown as a tooltip.

I've refactored some of the javascript because it wasn't obvious what it was doing. I thought that moving it into a well named function would make the intent of the code clearer.

Fixes: #178