### PR TITLE
Add link to open file in native application.

### DIFF
--- a/assets/src/scripts/_output-click.js
+++ b/assets/src/scripts/_output-click.js
@@ -209,11 +209,15 @@ ${outputComments.value[outputName]}</textarea
     const filePreviewTitle = newFilesContainer.querySelector(
       `[data-sacro-el="file-preview-template-title"]`
     );
+    const filePreviewLink = newFilesContainer.querySelector(
+      `[data-sacro-el="file-preview-template-link"]`
+    );
     const filePreviewContent = newFilesContainer.querySelector(
       `[data-sacro-el="file-preview-template-content"]`
     );
 
     filePreviewTitle.innerText = path;
+    filePreviewLink.setAttribute("href", url);
 
     if (isCsv(ext)) {
       createTableElement(filePreviewContent, ext, url, outcome);

--- a/sacro-app/src/create-window.js
+++ b/sacro-app/src/create-window.js
@@ -1,10 +1,10 @@
 const { session, BrowserWindow, Menu } = require("electron");
 const { dialog, shell } = require("electron");
-const fs = require("fs");
-const os = require("os");
-const path = require("path");
-const process = require("process");
-const querystring = require("querystring");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const process = require("node:process");
+const querystring = require("node:querystring");
 const { mainMenu } = require("./main-menu");
 const startServer = require("./start-server");
 const { waitThenLoad } = require("./utils");

--- a/sacro-app/src/create-window.js
+++ b/sacro-app/src/create-window.js
@@ -1,11 +1,15 @@
-const { BrowserWindow, Menu } = require("electron");
-const { dialog } = require("electron");
-const process = require("node:process");
+const { session, BrowserWindow, Menu } = require("electron");
+const { dialog, shell } = require("electron");
+const fs = require("fs");
 const os = require("os");
+const path = require("path");
+const process = require("process");
 const querystring = require("querystring");
 const { mainMenu } = require("./main-menu");
 const startServer = require("./start-server");
 const { waitThenLoad } = require("./utils");
+
+let TEMPDIR = null;
 
 const createWindow = async () => {
   let serverUrl = process.env.SACRO_URL;
@@ -18,6 +22,41 @@ const createWindow = async () => {
   }
 
   console.log(`Using ${serverUrl} as backend`);
+
+  // handle downloads
+  session.defaultSession.on("will-download", (event, item) => {
+    const [dispositionType] = item.getContentDisposition().split(";", 1);
+    // our output/feedback downloads, leave them alone.
+    if (dispositionType === "attachment") {
+      return;
+    }
+
+    // inline download, we want to download and open in native application
+
+    // create download dir if needed
+    if (TEMPDIR === null) {
+      try {
+        TEMPDIR = fs.mkdtempSync(path.join(os.tmpdir(), "sacro-"));
+      } catch (err) {
+        // TODO clean up on exit
+        // Note: this means if we fail to create the TMPDIR, we'll default to downloading the file normally.
+        console.error(err);
+        return;
+      }
+    }
+
+    const tmpPath = path.join(TEMPDIR, item.getFilename());
+    item.setSavePath(tmpPath);
+
+    item.once("done", (_, state) => {
+      if (state === "completed") {
+        // open in native application for this file type
+        shell.openPath(tmpPath);
+      } else {
+        console.error(`Download of ${item.getURL()} failed: ${state}`);
+      }
+    });
+  });
 
   const win = new BrowserWindow({
     width: 1024,

--- a/sacro/templates/components/button.html
+++ b/sacro/templates/components/button.html
@@ -1,13 +1,13 @@
 {% if type == "link" %}
   <a
-    {% attrs href %}
+    {% attrs data_sacro_el href %}
     {% if external %}
       rel="noopener noreferrer"
       target="_blank"
     {% endif %}
 {% else %}
   <button
-    {% attrs data_title disabled type=type|default:"button" id name value %}
+    {% attrs data_sacro_el data_title disabled type=type|default:"button" id name value %}
     {% if x_bind %}x-bind="{{ x_bind }}"{% endif %}
 {% endif %}
 

--- a/sacro/templates/index.html
+++ b/sacro/templates/index.html
@@ -137,8 +137,12 @@
 
       <template data-sacro-el="file-preview-template">
         <section class="bg-white shadow">
-          <h2 data-sacro-el="file-preview-template-title" class="text-lg font-semibold tracking-tight text-slate-900 px-4 py-2"></h2>
-          <a data-sacro-el="file-preview-template-link" class="">Open raw file</a>
+          <div class="flex flex-row items-center gap-4 justify-between flex-wrap px-4 py-2">
+            <h2 data-sacro-el="file-preview-template-title" class="text-lg font-semibold tracking-tight text-slate-900"></h2>
+            {% #button data_sacro_el="file-preview-template-link" href="#" small type="link" variant="secondary-outline" %}
+              Open file
+            {% /button %}
+          </div>
           <div data-sacro-el="file-preview-template-content" class="px-4 py-3 md:px-6 border-t border-slate-200 md:py-5"></div>
         </section>
       </template>

--- a/sacro/templates/index.html
+++ b/sacro/templates/index.html
@@ -138,6 +138,7 @@
       <template data-sacro-el="file-preview-template">
         <section class="bg-white shadow">
           <h2 data-sacro-el="file-preview-template-title" class="text-lg font-semibold tracking-tight text-slate-900 px-4 py-2"></h2>
+          <a data-sacro-el="file-preview-template-link" class="">Open raw file</a>
           <div data-sacro-el="file-preview-template-content" class="px-4 py-3 md:px-6 border-t border-slate-200 md:py-5"></div>
         </section>
       </template>


### PR DESCRIPTION
This adds download links to each file. With a regular browser, this will
download the file as usual, and can be opened.

In the electron app, we intercept the download, and then open it using
the system's native application for that file type. Because the user is
opening the downloaded copy, they cannot edit the original file via this
route, by design.
