### PR TITLE
View audit log

### DIFF
--- a/sacro-app/src/main-menu.js
+++ b/sacro-app/src/main-menu.js
@@ -1,4 +1,4 @@
-const { Menu, dialog, app, BrowserWindow } = require("electron");
+const { Menu, dialog, app, shell, BrowserWindow } = require("electron");
 const log = require("electron-log");
 const fs = require("fs");
 const os = require("node:os");
@@ -76,6 +76,15 @@ const mainMenu = (serverUrl) => {
     {
       role: "help",
       submenu: [
+        {
+          label: "View Audit Log",
+          click: async () => {
+            const auditFile = `${app.getPath("appData")}/SACRO/audit.log`;
+            const tempFile = `${app.getPath("temp")}/sacro-audit.log`;
+            fs.copyFileSync(auditFile, tempFile);
+            shell.openPath(tempFile);
+          },
+        },
         {
           role: "about",
         },

--- a/sacro/logging.py
+++ b/sacro/logging.py
@@ -1,17 +1,30 @@
-import os
+import sys
 from pathlib import Path
 
 import structlog
 
 
+def get_appdir():
+    home = Path.home()
+
+    if sys.platform == "win32":
+        return home / "AppData/Roaming"
+    if sys.platform == "linux":
+        return home / ".config"
+    if sys.platform == "darwin":
+        return home / "Library/Application Support"
+
+    return "."
+
+
 def get_log_filename():
-    filename = Path(os.getenv("APPDATA", ".")) / "SACRO" / "error.log"
+    filename = Path(get_appdir()) / "SACRO" / "error.log"
     filename.parent.mkdir(parents=True, exist_ok=True)
     return str(filename)
 
 
 def get_audit_filename():
-    filename = Path(os.getenv("APPDATA", ".")) / "SACRO" / "audit.log"
+    filename = Path(get_appdir()) / "SACRO" / "audit.log"
     filename.parent.mkdir(parents=True, exist_ok=True)
     return str(filename)
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,53 @@
+import os
+import sys
+
+from sacro import logging
+
+
+def test_get_appdir_on_unknown_os(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "unknown")
+    assert "." == logging.get_appdir()
+
+
+def test_get_log_filename_on_win32(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    assert os.path.join("AppData", "Roaming") in logging.get_log_filename()
+    assert "SACRO" in logging.get_log_filename()
+    assert "error.log" in logging.get_log_filename()
+
+
+def test_get_log_filename_on_linux(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    assert ".config" in logging.get_log_filename()
+    assert "SACRO" in logging.get_log_filename()
+    assert "error.log" in logging.get_log_filename()
+
+
+def test_get_log_filename_on_macos(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "darwin")
+    assert os.path.join("Library", "Application Support") in logging.get_log_filename()
+    assert "SACRO" in logging.get_log_filename()
+    assert "error.log" in logging.get_log_filename()
+
+
+def test_get_audit_filename_on_win32(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    assert os.path.join("AppData", "Roaming") in logging.get_audit_filename()
+    assert "SACRO" in logging.get_audit_filename()
+    assert "audit.log" in logging.get_audit_filename()
+
+
+def test_get_audit_filename_on_linux(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    assert ".config" in logging.get_audit_filename()
+    assert "SACRO" in logging.get_audit_filename()
+    assert "audit.log" in logging.get_audit_filename()
+
+
+def test_get_audit_filename_on_macos(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "darwin")
+    assert (
+        os.path.join("Library", "Application Support") in logging.get_audit_filename()
+    )
+    assert "SACRO" in logging.get_audit_filename()
+    assert "audit.log" in logging.get_audit_filename()


### PR DESCRIPTION
This provides a menu option to open up a temporary copy of the audit log in the OS's text editor.

As part of this change, the "app data" directory has been made consistent between Electron and Python. There's some implicit coupling here, which isn't great, but the app data dir / audit log location is unlikely to change and if Electron can't find the file it just does nothing when the menu item is clicked. One potential thing to consider is that the "app data" directory is now the same between the installed version and the development version.

Fixes #154

![Screenshot from 2023-07-11 16-12-37](https://github.com/opensafely-core/sacro/assets/3889554/b7c681f9-481f-44cf-bc52-c0cc9d51c579)
