### PR TITLE
Show exception requests

### DIFF
--- a/assets/src/scripts/_output-click.js
+++ b/assets/src/scripts/_output-click.js
@@ -12,6 +12,7 @@ import {
   setOutputTitle,
   setOutputType,
   setResearcherComments,
+  setExceptionRequest,
 } from "./_set-metadata";
 import {
   approvedOutputs,
@@ -75,6 +76,10 @@ export default async function outputClick({ outputName, metadata }) {
   );
   setAcroStatus(openOutput.value.metadata.summary);
   setResearcherComments(openOutput.value.metadata.comments);
+  setExceptionRequest(
+    openOutput.value.metadata.exception,
+    openOutput.value.metadata.status
+  );
 
   /**
    * Set up the review form

--- a/assets/src/scripts/_set-metadata.js
+++ b/assets/src/scripts/_set-metadata.js
@@ -111,3 +111,19 @@ export function setResearcherComments(comments) {
     toggleParentVisibility("outputDetailsComments", "div", "hide");
   }
 }
+
+/**
+ * Show the exception request for outputs that don't pass an acro check.
+ *
+ * @param {string} comment
+ * @param {string} status
+ */
+export function setExceptionRequest(comment, status) {
+  if (status === "pass") {
+    toggleParentVisibility("outputExceptionRequest", "div", "hide");
+    setElementHTML("outputExceptionRequest", ``);
+  } else {
+    toggleParentVisibility("outputExceptionRequest", "div", "show");
+    setElementHTML("outputExceptionRequest", comment);
+  }
+}

--- a/sacro/templates/index.html
+++ b/sacro/templates/index.html
@@ -124,6 +124,12 @@
               </dd>
             </div>
             <div class="px-4 py-2 grid grid-cols-4 gap-4 hidden" hidden>
+              <dt class="text-sm font-medium text-gray-900">Exception request</dt>
+              <dd class="text-sm leading-6 text-gray-700 col-span-3">
+                <span data-sacro-el="outputExceptionRequest"></span>
+              </dd>
+            </div>
+            <div class="px-4 py-2 grid grid-cols-4 gap-4 hidden" hidden>
               <dt class="text-sm font-medium text-gray-900">Review</dt>
               <dd class="text-sm leading-6 text-gray-700 col-span-3">
                 <span data-sacro-el="outputDetailsReviewForm" id="outputMetadata"></span>


### PR DESCRIPTION
Outputs that don't pass an ACRO check now show any exception request that has been given.

Fixes: #191

Pass (unchanged)
![Screenshot from 2023-07-12 17-47-24](https://github.com/opensafely-core/sacro/assets/3889554/4d92e8bc-d96c-4410-b770-77d7aa36aea2)

Failure
![Screenshot from 2023-07-12 17-47-16](https://github.com/opensafely-core/sacro/assets/3889554/4bb01e28-9f12-49a7-a2fb-516fd9447a6a)

Review custom output
![Screenshot from 2023-07-12 17-59-07](https://github.com/opensafely-core/sacro/assets/3889554/a88563b3-1429-4453-84e8-3c9de5dd3aba)
