### PR TITLE
Close the risk profile by default

### DIFF
--- a/sacro/templates/index.html
+++ b/sacro/templates/index.html
@@ -93,7 +93,7 @@
   <main class="container overflow-y-scroll">
     {{ outputs|json_script:"outputData" }}
 
-    <details class="overflow-hidden bg-white shadow mb-3" id="riskProfile" open>
+    <details class="overflow-hidden bg-white shadow mb-3" id="riskProfile">
       <summary class="pl-4 pr-2 py-2">
         <h3 class="ml-1 text-base font-medium leading-7 text-gray-900">
           ACRO risk profile


### PR DESCRIPTION
This is unlikely to be checked frequently by output checkers, although it's there if they need it. Therefore, we don't need to show it by default.