### PR TITLE
Show a blank page when someone cancels the file open dialog at startup

### DIFF
--- a/sacro-app/src/create-window.js
+++ b/sacro-app/src/create-window.js
@@ -82,7 +82,9 @@ const createWindow = async () => {
     ],
   });
 
-  if (!result.canceled) {
+  if (result.canceled) {
+    win.loadFile("no-file.html");
+  } else {
     const qs = querystring.stringify({ path: result.filePaths[0] });
     const url = `${serverUrl}?${qs}`;
 


### PR DESCRIPTION
This was leaving the app on the loading splash screen previously, but showing an error page here isn't quite correct either since this is not a true error because the user can always use the File menu to open the dialog again.

We've opted for a blank page for now so that we can quickly avoid using the error page.