### PR TITLE
Add support for directories of files without ACRO metdata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,14 @@
 .wenv/
 .ipynb*
 .pytest-cache/
+.ruff_cache
+.pytest_cache
 .coverage
 __pycache__
 .*.sw*
 /build
 sacro-app/dist
+sacro-app/SACRO
 node_modules/
 assets/dist
 sacro/staticfiles/

--- a/README.md
+++ b/README.md
@@ -31,14 +31,10 @@ When the installation completes, it will run the application.
 
 ## Usage
 
-To view some ACRO outputs, you need to open the ACRO generated JSON file for
-those outputs.
+To view outputs, you need to open a directory containing the output files. The Viewer will detect if there is ACRO-generated metadata, and use that to display the files. If there is no ACRO data, it will generate some, adding each file in the directory as a `custom` ACRO outputs.
 
-If you don't have any, you can use the test outputs we have included in the
-downloaded zip to get started with.
-
-Navigate to and select the `.json` file in the ACRO `outputs` directory (`results.json` by
-default). If  you are using the test outputs, it is `outputs\results.json`.
+If you don't have any outputs to hand, you can use the test outputs we have included in the
+downloaded zip to get started with: navigate to and select directory `outputs`  in the zip file.
 
 In the appliction, you should now see the list of outputs on the left, and can
 select each one to view it.

--- a/sacro-app/src/create-window.js
+++ b/sacro-app/src/create-window.js
@@ -73,20 +73,16 @@ const createWindow = async () => {
   });
 
   const result = await dialog.showOpenDialog({
-    title: "Choose ACRO outputs json file",
-    properties: ["openFile"],
+    title: "Choose directory containing outputs you wish to review",
+    properties: ["openDirectory"],
     defaultPath: os.homedir(),
-    filters: [
-      { name: "ACRO Outputs", extensions: ["json", "acro"] },
-      { name: "All files", extensions: ["*"] },
-    ],
   });
 
   if (result.canceled) {
     win.loadFile("no-file.html");
   } else {
-    const qs = querystring.stringify({ path: result.filePaths[0] });
-    const url = `${serverUrl}?${qs}`;
+    const qs = querystring.stringify({ dirpath: result.filePaths[0] });
+    const url = `${serverUrl}/load?${qs}`;
 
     const timeout = serverProcess === null ? 0 : 4000;
     waitThenLoad(url, timeout)

--- a/sacro-app/src/create-window.js
+++ b/sacro-app/src/create-window.js
@@ -11,6 +11,14 @@ const { waitThenLoad } = require("./utils");
 
 let TEMPDIR = null;
 
+function rtrim(x, characters) {
+  let end = x.length - 1;
+  while (characters.indexOf(x[end]) >= 0) {
+    end -= 1;
+  }
+  return x.substr(0, end + 1);
+}
+
 const createWindow = async () => {
   let serverUrl = process.env.SACRO_URL;
   let serverProcess = null;
@@ -20,6 +28,8 @@ const createWindow = async () => {
     serverUrl = url;
     serverProcess = server;
   }
+
+  serverUrl = rtrim(serverUrl, "/");
 
   console.log(`Using ${serverUrl} as backend`);
 

--- a/sacro-app/src/main-menu.js
+++ b/sacro-app/src/main-menu.js
@@ -12,25 +12,21 @@ const mainMenu = (serverUrl) => {
       label: "File",
       submenu: [
         {
-          label: "Open File",
+          label: "Open Directory",
           accelerator: "CommandOrControl+O",
           click: async () => {
             dialog
               .showOpenDialog({
-                title: "Choose ACRO outputs json file",
-                properties: ["openFile"],
+                title: "Choose directory containing outputs you wish to review",
+                properties: ["openDirectory"],
                 defaultPath: os.homedir(),
-                filters: [
-                  { name: "ACRO Outputs", extensions: ["json", "acro"] },
-                  { name: "All files", extensions: ["*"] },
-                ],
               })
               .then((result) => {
                 if (!result.canceled) {
                   const qs = querystring.stringify({
-                    path: result.filePaths[0],
+                    dirpath: result.filePaths[0],
                   });
-                  const url = `${serverUrl}?${qs}`;
+                  const url = `${serverUrl}/load?${qs}`;
                   BrowserWindow.getFocusedWindow().loadURL(url);
                 }
               })

--- a/sacro/models.py
+++ b/sacro/models.py
@@ -48,6 +48,7 @@ def find_acro_metadata(dirpath):
 
 def scaffold_acro_metadata(path):
     dirpath = path.parent
+    checksums_dir = dirpath / "checksums"
     metadata = {
         "version": "0.4.0",
         "results": {},
@@ -71,9 +72,16 @@ def scaffold_acro_metadata(path):
             "exception": None,
             "timestamp": datetime.fromtimestamp(output.stat().st_mtime).isoformat(),
             "comments": [
-                "This ACRO output was auto generated the SACRO Viewer application",
+                "This non-ACRO output metadata was auto generated the SACRO Viewer application",
             ],
         }
+
+        # Write the checksums at the time of first looking at the directory
+        # This is a bit of a hack. Ideally, we'd find a way to disable checksums in such cases
+        checksums_dir.mkdir(exist_ok=True)
+        checksum_path = checksums_dir / (output.name + ".txt")
+        checksum_path.write_text(hashlib.sha256(output.read_bytes()).hexdigest())
+
     path.write_text(json.dumps(metadata, indent=2))
 
 

--- a/sacro/templates/error.html
+++ b/sacro/templates/error.html
@@ -23,7 +23,7 @@
       <div class="flex flex-col gap-y-4 text-lg">
         <p class="break-words">
           {% if message %}
-            {{ message }}
+            {{ message|linebreaks }}
           {% else %}
             Please restart the application and try again.<br />
             If this problem continues please contact support.

--- a/sacro/urls.py
+++ b/sacro/urls.py
@@ -8,6 +8,7 @@ from sacro import errors, views
 
 urlpatterns = [
     path("", views.index, name="index"),
+    path("load/", views.load, name="load"),
     path("contents/", views.contents, name="contents"),
     path("error/", errors.error, name="error"),
     path("review/", views.review_create, name="review-create"),

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -12,6 +12,26 @@ from django.urls import reverse
 from sacro import models, views
 
 
+def test_load(test_outputs):
+    request = RequestFactory().get(
+        path="/load", data={"dirpath": str(test_outputs.path.parent)}
+    )
+    response = views.load(request)
+    assert response.status_code == 302
+    assert response.headers["Location"] == f"/?{urlencode({'path': test_outputs.path})}"
+
+
+def test_load_multiple(test_outputs):
+    (test_outputs.path.parent / "valid.json").write_text(
+        json.dumps(test_outputs.raw_metadata)
+    )
+    request = RequestFactory().get(
+        path="/load", data={"dirpath": str(test_outputs.path.parent)}
+    )
+    response = views.load(request)
+    assert response.status_code == 500
+
+
 def test_index(test_outputs):
     request = RequestFactory().get(path="/", data={"path": str(test_outputs.path)})
 


### PR DESCRIPTION
This means changing to use a directory picker, rather than a file
picker. This means a bit of guess work when there are acro metadata
files in the directory. The upshot of this is:

a) we now launch the app in a special /load url to do this guess work
b) we no longer support a directory with multiple acro metadata files in

Fixes #235 
